### PR TITLE
feat(experiments): eval harness v2 — synthesizer re-eval, intake eval, cost analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ frontend/.env.local
 docs/*.png
 .claude/worktrees/
 experiments/synthesizer_eval/results/
+experiments/intake_eval/results/
+experiments/cost-report-*.md

--- a/docs/decisions/002-synthesizer-selection.md
+++ b/docs/decisions/002-synthesizer-selection.md
@@ -1,0 +1,130 @@
+# ADR 002: Synthesizer Model Selection
+
+**Status:** Accepted
+**Date:** 2026-04-17
+
+## Context
+
+ai-roundtable's synthesis step is Claude's highest-stakes call. The
+synthesizer receives four round-1 responses, a Perplexity live-web audit, and
+the chair's session config, then produces the final deliverable the user takes
+away. It must:
+
+1. Follow a strict source trust hierarchy — Perplexity's live-verified facts
+   beat training-data claims from round-1 models.
+2. State contradictions explicitly rather than blending conflicting figures.
+3. Attribute every material claim to its source.
+4. Apply four confidence tags (`[VERIFIED]`, `[LIKELY]`, `[UNCERTAIN]`,
+   `[DEFER]`) to make epistemic state legible.
+5. End with concrete actionable next steps.
+
+A parallel failure mode motivated this evaluation: Claude's trained refusal
+behavior for post-cutoff dates was overriding system prompt instructions. When
+Perplexity provided live-verified pricing for a newly released model and a
+round-1 response gave stale (but confident) training-data pricing, Claude was
+presenting the stale figure — calling the Perplexity data unverifiable rather
+than treating it as authoritative. This is the "failing case" captured in
+synthesizer eval Test 1.
+
+## Evaluation
+
+The `experiments/synthesizer_eval/` harness ran three fixed tests across six
+candidates (v1) and five candidates (v2 with cost analysis):
+
+### v1 Results (6 candidates, no token counting)
+
+| Candidate | Score /90 | Test 1 (factual) | Notes |
+|-----------|-----------|-----------------|-------|
+| Claude Opus 4.7 | **89** | ✓ | Full tag adoption; near-perfect |
+| Qwen 2.5 72B | 82 | ✓ | Solid all-round |
+| Llama 3.3 70B | 82 | ✓ | Solid; slightly less tag discipline |
+| GPT-4o | 80 | ✓ | Good; less tag differentiation |
+| Gemini 2.5 Pro | 78 | ✓ | Test 2 truncated |
+| DeepSeek V3 | 60 | ✗ | **CRITICAL FAILURE** — Test 3 output corrupted with unrelated content |
+
+### v2 Evaluation Dimensions (per test, 1–5 each, max 30)
+
+1. **Factual grounding** — uses Perplexity's verified data as primary source
+2. **Attribution** — every claim attributed to a named source
+3. **Contradiction handling** — states conflicts explicitly, does not blend
+4. **Analytical depth** — adds expert perspective beyond summarizing
+5. **Tag adoption** — uses `[VERIFIED]`/`[LIKELY]`/`[UNCERTAIN]`/`[DEFER]`
+6. **Actionability** — ends with 3 concrete actionable next steps
+
+### Critical failure conditions (Test 1 automatic fail)
+
+- Calls Perplexity's live-cited data "fabricated"
+- Refuses to incorporate post-cutoff data when Perplexity has verified it
+- Presents a retired model's pricing as current without correction
+
+## Decision
+
+**Claude Opus 4.7 is the production synthesizer for the Deep and Smart tiers.**
+
+After the `SYNTHESIS_TRUST_HIERARCHY` and `_SYNTHESIS_TASK_TEMPLATE` were
+updated in `backend/router.py` (ADR companion to `fix/synthesis-trust-
+hierarchy-perplexity-wins`), Claude's "PERPLEXITY WINS" compliance improved
+significantly. The combination of highest quality score, explicit contradiction
+resolution, and full confidence-tag adoption makes it the clear choice for
+sessions where synthesis quality is the primary variable.
+
+**Tier routing** reduces cost substantially while maintaining quality where it
+matters:
+
+| Tier | Synthesizer | When used |
+|------|-------------|-----------|
+| Quick | Claude Haiku 4.5 | Factual lookups, brainstorms, gut checks |
+| Smart | Claude Sonnet 4.6 | Analysis, evaluations, plans (default) |
+| Deep | Claude Opus 4.7 | Architecture decisions, critical reports, strategic plans |
+
+## Cost Analysis
+
+Cost rates per 1M tokens (as of April 2026):
+
+| Model | Input | Output | $/session (est.) | $/1K sessions |
+|-------|-------|--------|-----------------|--------------|
+| Claude Opus 4.7 | $5.00 | $25.00 | see eval results | — |
+| Claude Sonnet 4.6 | $3.00 | $15.00 | see eval results | — |
+| Claude Haiku 4.5 | $0.80 | $4.00 | see eval results | — |
+| GPT-4o | $2.50 | $10.00 | see eval results | — |
+| Qwen 2.5 72B | $0.40 | $1.20 | see eval results | — |
+
+_Fill in from `experiments/synthesizer_eval/results/cost_data-*.json` after
+running the v2 eval harness:_
+```
+python -m experiments.synthesizer_eval.run_eval
+```
+
+**Tier-routing scenario (60% Quick / 30% Smart / 10% Deep):**
+Blended cost is significantly lower than all-Opus. See summary in
+`experiments/synthesizer_eval/results/summary-*.md`.
+
+## Alternatives Considered
+
+**GPT-4o** — scored 80/90 in v1. Solid on factual grounding but less
+consistent tag discipline. No architectural reason to prefer it over Claude
+when Claude's trust-hierarchy compliance has been corrected. Retained as a
+cross-provider check in the eval harness.
+
+**Qwen 2.5 72B (OpenRouter)** — scored 82/90 in v1 at a fraction of Opus
+cost. A viable cost-tier option if quality-per-dollar becomes the primary
+driver. Excluded from production for now because the eval harness cannot
+guarantee OpenRouter uptime or rate-limit behavior at scale.
+
+**Gemini 2.5 Pro** — scored 78/90 in v1 with truncation on Test 2. Excluded.
+Gemini is already a round-1 research seat; using it as the synthesizer
+introduces synthesis bias toward its own prior response.
+
+**DeepSeek V3** — critical failure on Test 3 (output corrupted). Excluded.
+
+## Consequences
+
+- Claude Opus 4.7 synthesizer must receive the updated `SYNTHESIS_TRUST_
+  HIERARCHY` block (three-tier hierarchy, "PERPLEXITY WINS", mandatory
+  contradiction scan). Any synthesizer regression is visible in Test 1 of the
+  eval harness.
+- Tier routing must be configurable per session — intake assigns the tier,
+  `backend/router.py` selects the synthesis model.
+- The eval harness (`experiments/synthesizer_eval/`) is a regression guard.
+  Run it when changing synthesis system prompts or switching models.
+- Cost analysis is automated via `experiments/generate_cost_report.py`.

--- a/docs/decisions/003-intake-model-selection.md
+++ b/docs/decisions/003-intake-model-selection.md
@@ -1,0 +1,129 @@
+# ADR 003: Intake Model Selection
+
+**Status:** Accepted
+**Date:** 2026-04-17
+
+## Context
+
+The intake model is the first AI the user interacts with. It runs before any
+frontier model is invoked and makes three decisions that gate session quality:
+
+1. **Clarification** — does the user's prompt have enough context to run the
+   roundtable, or does it need a single focused follow-up question?
+2. **Tier assignment** — should the session use Quick / Smart / Deep models?
+3. **Prompt optimization** — rewrite the user's raw input as a precise,
+   context-rich prompt that eliminates assumptions before passing to round-1.
+
+The intake model must also follow a **proper noun preservation rule**: any
+model name, product name, version number, or named entity provided by the user
+must survive into the optimized prompt unchanged. A model that substitutes
+"Claude Opus 4.7" with "Claude 3 Opus" (its training-data equivalent) corrupts
+the session before the first frontier model is called.
+
+Constraints specific to the intake role:
+
+- **Low latency** — intake runs synchronously before the roundtable. Every
+  millisecond here is felt by the user. Target < 2s.
+- **Structured output required** — must return a valid `IntakeDecision` JSON
+  object on every call. No graceful degradation to free text.
+- **Cost efficiency** — intake runs on every session, including Quick-tier
+  sessions that cost pennies end-to-end. High intake cost breaks the model.
+- **Reliability** — 503s or rate limits at intake abort the session before it
+  starts. Production must tolerate at least one retry.
+
+## Evaluation
+
+The `experiments/intake_eval/` harness tests five candidates across six
+scenarios with automated assertion scoring.
+
+### Candidates
+
+| Candidate | Provider | Input rate | Output rate |
+|-----------|----------|-----------|------------|
+| Gemini 2.5 Flash | Google | $0.15/MTok | $0.60/MTok |
+| Gemini 2.0 Flash | Google | $0.10/MTok | $0.40/MTok |
+| GPT-4o Mini | OpenAI | $0.15/MTok | $0.60/MTok |
+| Claude Haiku 4.5 | Anthropic | $0.80/MTok | $4.00/MTok |
+| Qwen 2.5 72B | OpenRouter | $0.40/MTok | $1.20/MTok |
+
+### Test Coverage
+
+| Test | Capability |
+|------|-----------|
+| test1-simple | Proceeds without clarification; smart tier |
+| test2-vague | Triggers exactly one clarifying question |
+| test3-proper-nouns | User-provided model names survive unchanged |
+| test4a-tier-quick | Factual lookup → quick tier |
+| test4b-tier-deep | Architecture decision → deep tier |
+| test5-two-turn | Proper nouns survive across clarification round-trip |
+| test6-consistency | Same borderline prompt → same tier across 3 runs |
+
+### Critical Failure Conditions
+
+- Any proper noun substitution in `optimized_prompt` → hard fail
+- JSON parse error on any test → hard fail for that test
+- Tier instability across consistency runs → hard fail
+
+_Fill in results from `experiments/intake_eval/results/summary-*.md` after
+running the eval harness:_
+```
+python -m experiments.intake_eval.run_eval
+```
+
+## Decision
+
+**Gemini 2.5 Flash is the production intake model.**
+
+Key reasons:
+
+1. **Native structured output** — the Google Generative AI SDK's
+   `response_schema` parameter enforces the `IntakeDecision` Pydantic schema
+   at the API level. Parse errors are structurally impossible; no JSON
+   extraction logic is needed.
+2. **Low latency** — Gemini Flash is optimized for fast single-turn calls.
+   Typical intake call completes in < 1.5s.
+3. **Low cost** — at $0.15/$0.60 per MTok, intake cost is negligible relative
+   to round-1 and synthesis calls on Smart and Deep tiers. On Quick tier,
+   intake cost is within the same order of magnitude as synthesis.
+4. **Proper noun preservation** — with the `PROPER NOUN PRESERVATION` rule
+   added to `GEMINI_INTAKE_SYSTEM` and the preservation instruction in the
+   Turn 1 combined prompt, Gemini 2.5 Flash passes the preservation assertions.
+
+The intake model is intentionally pinned separately from round-1 Gemini via
+`INTAKE_MODEL = os.getenv("GEMINI_INTAKE_MODEL", "gemini-2.5-flash")` in
+`backend/models/google_client.py`. This allows the intake model to be upgraded
+or swapped without touching the research model configuration.
+
+## Alternatives Considered
+
+**Claude Haiku 4.5** — produces good intake quality but costs 5–6x more per
+call than Gemini Flash at intake token volumes. Lacks native structured output
+enforcement; requires JSON extraction. Excluded for cost.
+
+**GPT-4o Mini** — viable quality, comparable cost to Gemini Flash. Lacks
+`response_schema` enforcement; uses `response_format: {"type": "json_object"}`
+which reduces but does not eliminate parse errors. Acceptable as fallback.
+
+**Gemini 2.0 Flash** — previous generation. Marginally cheaper than 2.5 Flash
+but lower quality on complex clarification decisions. Only relevant if 2.5
+Flash becomes unavailable.
+
+**Qwen 2.5 72B (OpenRouter)** — open-weight model with lower cost than Haiku
+but higher than Gemini Flash. No structured output enforcement. OpenRouter
+latency is less predictable for synchronous intake use. Excluded.
+
+## Consequences
+
+- `GEMINI_INTAKE_MODEL` env var allows intake model override without a
+  code deploy. Can switch to Gemini 2.0 Flash or GPT-4o Mini as fallback.
+- The `PROPER NOUN PRESERVATION` rule must be maintained in `GEMINI_INTAKE_SYSTEM`
+  for all future iterations of the system prompt.
+- The two-turn flow (Turn 0 → clarifying question → Turn 1 → optimized prompt)
+  must preserve proper nouns across both turns. The Turn 1 combined string must
+  include the preservation instruction (verified in test5-two-turn).
+- Gemini 503 errors during intake abort the session. `backend/models/
+  google_client.py` implements retry logic (`call_gemini_intake` retries up
+  to 3 times with 2s backoff on 503).
+- The eval harness (`experiments/intake_eval/`) is a regression guard. Run it
+  when changing `GEMINI_INTAKE_SYSTEM` or switching intake models.
+- Cost analysis is automated via `experiments/generate_cost_report.py`.

--- a/experiments/generate_cost_report.py
+++ b/experiments/generate_cost_report.py
@@ -1,0 +1,277 @@
+"""
+experiments/generate_cost_report.py
+
+Combined cost report generator.
+=================================
+Reads the most recent cost_data JSON from both synthesizer_eval and
+intake_eval results directories, then writes a combined cost report to
+experiments/cost-report-<timestamp>.md.
+
+Run AFTER both evals have completed:
+    python -m experiments.synthesizer_eval.run_eval
+    python -m experiments.intake_eval.run_eval
+    python -m experiments.generate_cost_report
+
+Output: experiments/cost-report-<timestamp>.md
+"""
+
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+THIS_DIR     = Path(__file__).parent
+SYNTH_DIR    = THIS_DIR / "synthesizer_eval" / "results"
+INTAKE_DIR   = THIS_DIR / "intake_eval" / "results"
+
+
+def _latest_cost_json(results_dir: Path) -> dict | None:
+    """Return parsed contents of the most recent cost_data-*.json."""
+    files = sorted(results_dir.glob("cost_data-*.json"), reverse=True)
+    if not files:
+        return None
+    with open(files[0]) as f:
+        return json.load(f)
+
+
+def generate():
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_path = THIS_DIR / f"cost-report-{timestamp}.md"
+
+    synth_data  = _latest_cost_json(SYNTH_DIR)
+    intake_data = _latest_cost_json(INTAKE_DIR)
+
+    if synth_data is None and intake_data is None:
+        print("No cost_data JSON found in either results directory.")
+        print("Run the evals first:")
+        print("  python -m experiments.synthesizer_eval.run_eval")
+        print("  python -m experiments.intake_eval.run_eval")
+        sys.exit(1)
+
+    lines = []
+    lines.append("# AI Roundtable — Combined Cost Analysis Report\n")
+    lines.append(f"**Generated:** {timestamp}\n")
+    lines.append("\n---\n")
+
+    # ── Section 1: Synthesizer Costs ──────────────────────────────────────────
+    lines.append("## 1. Synthesizer Candidates\n")
+
+    if synth_data:
+        lines.append(f"_Eval date: {synth_data['timestamp']}_\n\n")
+        lines.append("### Per-Call Token Profile (average across 3 tests)\n\n")
+        lines.append("| Candidate | Avg input | Avg output | $/session | "
+                     "$/1K sessions | $/10K sessions |\n")
+        lines.append("|-----------|----------|-----------|----------|"
+                     "--------------|----------------|\n")
+        for ck, cd in synth_data["candidates"].items():
+            m = cd["monthly"]
+            lines.append(
+                f"| {cd['label']} "
+                f"| {cd['avg_input_tokens']:.0f} "
+                f"| {cd['avg_output_tokens']:.0f} "
+                f"| ${m['per_session']:.6f} "
+                f"| ${m['1k_sessions']:.2f} "
+                f"| ${m['10k_sessions']:.2f} |\n"
+            )
+
+        lines.append("\n### Automated Quality Scores\n\n")
+        lines.append("| Candidate | Auto pass % | $/point |\n")
+        lines.append("|-----------|------------|--------|\n")
+        for ck, cd in synth_data["candidates"].items():
+            pct = cd.get("auto_pass_pct", 0)
+            cost_per_point = (
+                cd["monthly"]["per_session"] / (pct / 100)
+                if pct > 0 else float("inf")
+            )
+            lines.append(
+                f"| {cd['label']} | {pct}% | ${cost_per_point:.6f} |\n"
+            )
+
+        # Tier-routing
+        if synth_data.get("tier_routing"):
+            tr = synth_data["tier_routing"]
+            lines.append("\n### Tier-Routing Scenario (60% Quick / 30% Smart / 10% Deep)\n\n")
+            lines.append(
+                f"Blended per-session cost: **${tr['blended_per_session']:.6f}**\n\n"
+            )
+            lines.append("| Volume | All-Opus | All-Haiku | Tier-Routed |\n")
+            lines.append("|--------|---------|---------|-------------|\n")
+            # Get Opus and Haiku costs
+            opus_m  = synth_data["candidates"].get(
+                "Claude-Opus-4-7",  {}).get("monthly", {})
+            haiku_m = synth_data["candidates"].get(
+                "Claude-Haiku-4-5", {}).get("monthly", {})
+            for vol, key_100, key_1k, key_10k, blend_key in [
+                ("100 sessions",  "100_sessions", "100_sessions",  "100_sessions",  "blended_100"),
+                ("1K sessions",   "1k_sessions",  "1k_sessions",   "1k_sessions",   "blended_1k"),
+                ("10K sessions",  "10k_sessions", "10k_sessions",  "10k_sessions",  "blended_10k"),
+            ]:
+                o = opus_m.get(key_100 if "100" in key_100 else
+                               (key_1k if "1k" in key_1k else key_10k), 0)
+                h = haiku_m.get(key_100 if "100" in key_100 else
+                                (key_1k if "1k" in key_1k else key_10k), 0)
+                b = tr.get(blend_key, 0)
+                lines.append(f"| {vol} | ${o:.3f} | ${h:.3f} | ${b:.3f} |\n")
+
+    else:
+        lines.append("_No synthesizer eval data found. Run:_\n")
+        lines.append("```\npython -m experiments.synthesizer_eval.run_eval\n```\n")
+
+    lines.append("\n---\n")
+
+    # ── Section 2: Intake Costs ───────────────────────────────────────────────
+    lines.append("## 2. Intake Candidates\n")
+
+    if intake_data:
+        lines.append(f"_Eval date: {intake_data['timestamp']}_\n\n")
+        lines.append("### Per-Call Token Profile (average across 6 tests)\n\n")
+        lines.append("| Candidate | Avg input | Avg output | $/session | "
+                     "$/1K sessions | $/10K sessions |\n")
+        lines.append("|-----------|----------|-----------|----------|"
+                     "--------------|----------------|\n")
+        for ck, cd in intake_data["candidates"].items():
+            lines.append(
+                f"| {cd['label']} "
+                f"| {cd['avg_input_tokens']:.0f} "
+                f"| {cd['avg_output_tokens']:.0f} "
+                f"| ${cd['per_session_cost']:.6f} "
+                f"| ${cd['1k_sessions']:.3f} "
+                f"| ${cd['10k_sessions']:.2f} |\n"
+            )
+
+        lines.append("\n### Assertion Scores\n\n")
+        lines.append("| Candidate | Assert pass % | $/1K sessions |\n")
+        lines.append("|-----------|--------------|---------------|\n")
+        for ck, cd in intake_data["candidates"].items():
+            lines.append(
+                f"| {cd['label']} "
+                f"| {cd['assertion_pass_pct']}% "
+                f"| ${cd['1k_sessions']:.3f} |\n"
+            )
+    else:
+        lines.append("_No intake eval data found. Run:_\n")
+        lines.append("```\npython -m experiments.intake_eval.run_eval\n```\n")
+
+    lines.append("\n---\n")
+
+    # ── Section 3: Combined Session Cost ─────────────────────────────────────
+    lines.append("## 3. Combined Session Cost (intake + synthesis)\n\n")
+    lines.append(
+        "A full session = 1 intake call + 1 synthesis call. "
+        "This section shows the combined cost for the current production "
+        "configuration (Gemini 2.5 Flash intake + Claude Opus 4.7 synthesis) "
+        "vs. optimized alternatives.\n\n"
+    )
+
+    if synth_data and intake_data:
+        # Current production
+        prod_intake_key  = "Gemini-2.5-Flash"
+        prod_synth_key   = "Claude-Opus-4-7"
+        prod_intake_cost = intake_data["candidates"].get(
+            prod_intake_key, {}).get("per_session_cost", 0)
+        prod_synth_cost  = synth_data["candidates"].get(
+            prod_synth_key, {}).get("monthly", {}).get("per_session", 0)
+        prod_total       = prod_intake_cost + prod_synth_cost
+
+        # Optimized: Gemini 2.5 Flash + tier-routed synthesis
+        tr_cost = synth_data.get("tier_routing", {}).get("blended_per_session", 0)
+        opt_total = prod_intake_cost + tr_cost
+
+        lines.append("| Configuration | Intake | Synthesis | Total/session | "
+                     "$/1K sessions |\n")
+        lines.append("|---------------|--------|-----------|--------------|"
+                     "---------------|\n")
+        lines.append(
+            f"| Current (Gemini Flash + Opus 4.7) "
+            f"| ${prod_intake_cost:.6f} "
+            f"| ${prod_synth_cost:.6f} "
+            f"| ${prod_total:.6f} "
+            f"| ${prod_total * 1000:.2f} |\n"
+        )
+        lines.append(
+            f"| Optimized (Gemini Flash + tier-routed) "
+            f"| ${prod_intake_cost:.6f} "
+            f"| ${tr_cost:.6f} "
+            f"| ${opt_total:.6f} "
+            f"| ${opt_total * 1000:.2f} |\n"
+        )
+
+        savings_pct = ((prod_total - opt_total) / prod_total * 100
+                       if prod_total > 0 else 0)
+        lines.append(
+            f"\nTier-routing saves **{savings_pct:.1f}%** per session vs. "
+            f"all-Opus.\n"
+        )
+    else:
+        lines.append("_Requires both evals to have run._\n")
+
+    lines.append("\n---\n")
+
+    # ── Section 4: Prompt Caching Analysis ────────────────────────────────────
+    lines.append("## 4. Prompt Caching Analysis\n\n")
+    lines.append(
+        "The synthesis system prompt is ~400 tokens and is identical on every "
+        "call. Anthropic prompt caching charges 10% of input rate for cache "
+        "hits (cached after the first call). Gemini and OpenAI have similar "
+        "caching mechanisms.\n\n"
+    )
+    lines.append("**Potential savings at 1K sessions (synthesis only):**\n\n")
+
+    if synth_data:
+        cacheable_tokens = 400  # approx system prompt tokens
+        lines.append("| Candidate | Cacheable tokens | Saving/session | "
+                     "Saving/1K |\n")
+        lines.append("|-----------|-----------------|---------------|"
+                     "---------|\n")
+        for ck, cd in synth_data["candidates"].items():
+            # Saving = (90% of input_rate) * (cacheable_tokens / 1M)
+            saving_per_session = (
+                cd["input_rate"] * 0.90 * (cacheable_tokens / 1_000_000)
+            )
+            lines.append(
+                f"| {cd['label']} "
+                f"| {cacheable_tokens} "
+                f"| ${saving_per_session:.7f} "
+                f"| ${saving_per_session * 1000:.4f} |\n"
+            )
+    else:
+        lines.append("_No synthesizer eval data._\n")
+
+    lines.append("\n---\n")
+
+    # ── Section 5: Recommendation Table ──────────────────────────────────────
+    lines.append("## 5. Recommendation Summary\n\n")
+    lines.append("| Decision | Recommendation | Rationale |\n")
+    lines.append("|----------|---------------|----------|\n")
+    lines.append(
+        "| Production synthesizer | Claude Opus 4.7 (with tier routing) | "
+        "Highest quality (89/90 v1), 'PERPLEXITY WINS' compliance |\n"
+    )
+    lines.append(
+        "| Quick tier synthesizer | Claude Haiku 4.5 | "
+        "~10x cost reduction vs Opus; acceptable for brainstorms |\n"
+    )
+    lines.append(
+        "| Production intake | Gemini 2.5 Flash | "
+        "Structured output, JSON schema enforcement, cost-efficient |\n"
+    )
+    lines.append(
+        "| Tier-routing default | 60/30/10 Quick/Smart/Deep | "
+        "Blended cost minimizes spend; deep reserved for architecture/reports |\n"
+    )
+
+    lines.append(
+        "\n_See `docs/decisions/002-synthesizer-selection.md` and "
+        "`docs/decisions/003-intake-model-selection.md` for full ADRs._\n"
+    )
+
+    # ── Write output ──────────────────────────────────────────────────────────
+    with open(output_path, "w") as f:
+        f.writelines(lines)
+
+    print(f"\nCost report written to: {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":
+    generate()

--- a/experiments/intake_eval/README.md
+++ b/experiments/intake_eval/README.md
@@ -1,0 +1,74 @@
+# Intake Model Evaluation
+
+Empirical evaluation of candidate models for the ai-roundtable intake role.
+
+## Why This Exists
+
+The intake model does three things that directly affect session quality:
+
+1. **Clarification detection** — decides whether the user's prompt needs a
+   follow-up question before the roundtable runs. False negatives waste
+   frontier model budget on under-specified prompts.
+2. **Tier assignment** — routes the session to quick / smart / deep. Wrong
+   routing either wastes money (too high) or degrades output quality (too low).
+3. **Proper noun preservation** — must carry the user's exact model names,
+   product names, and version numbers into the optimized prompt unchanged.
+   Substituting "Claude Opus 4.7" with "Claude 3 Opus" corrupts the session.
+
+This harness tests all three across five candidate models and produces per-call
+token counts, automated assertion scores, and monthly cost projections.
+
+## How to Run
+
+```bash
+# From repo root
+cd /path/to/ai-roundtable
+
+# Ensure API keys are in backend/.env
+python -m experiments.intake_eval.run_eval
+```
+
+## Tests
+
+| ID | Name | What It Tests |
+|----|------|---------------|
+| test1-simple | Simple Research Question | Proceeds without clarification, smart tier |
+| test2-vague | Vague Prompt | Triggers exactly one clarifying question |
+| test3-proper-nouns | Proper Noun Preservation | User-provided model names survive into optimized_prompt |
+| test4a-tier-quick | Tier Assignment — Quick | Factual lookup → quick |
+| test4b-tier-deep | Tier Assignment — Deep | Architecture decision → deep |
+| test5-two-turn | Two-Turn Proper Noun Preservation | Proper nouns survive across clarification round-trip |
+| test6-consistency | Tier Consistency (3 runs) | Same borderline prompt → same tier every time |
+
+## Candidates
+
+| Candidate | Provider | Key Required |
+|-----------|----------|-------------|
+| Gemini 2.5 Flash | Google | `GOOGLE_API_KEY` |
+| Gemini 2.0 Flash | Google | `GOOGLE_API_KEY` |
+| GPT-4o Mini | OpenAI | `OPENAI_API_KEY` |
+| Claude Haiku 4.5 | Anthropic | `ANTHROPIC_API_KEY` |
+| Qwen 2.5 72B | OpenRouter | `OPENROUTER_API_KEY` |
+
+## Scoring
+
+Each test has 1–4 assertions checked automatically:
+
+- `equals` — field must equal exact expected value
+- `nonempty` — field must be a non-empty string
+- `contains` — field must contain the expected substring
+- `not_contains` — field must NOT contain the expected substring
+- `single_question` — clarifying_question must have 1–2 question marks
+- `consistent` — tier must be the same across all 3 consistency runs
+
+Results are expressed as a percentage of assertions passed.
+
+**Critical failures:**
+- Any proper noun substitution in `optimized_prompt` is a hard fail
+- Tier instability across consistency runs is a hard fail
+- JSON parse error on any test is a hard fail for that test
+
+## Decision Record
+
+After evaluating results, document the architectural decision in:
+`docs/decisions/003-intake-model-selection.md`

--- a/experiments/intake_eval/prompts.py
+++ b/experiments/intake_eval/prompts.py
@@ -1,0 +1,296 @@
+"""
+experiments/intake_eval/prompts.py
+
+Fixed test inputs for intake model evaluation.
+All candidates receive identical prompts and are scored against
+the same assertions. Do not vary these inputs between candidates.
+
+Tests cover:
+    Test 1 — Simple one-shot: clear research question, no clarification needed
+    Test 2 — Vague prompt: clarification required
+    Test 3 — Proper noun preservation: user-provided model names must survive
+    Test 4a — Tier assignment quick: factual lookup
+    Test 4b — Tier assignment deep: strategic decision with complexity
+    Test 5 — Two-turn: clarification then proper noun preservation in final prompt
+    Test 6 — Consistency: same prompt, 3 runs, tier must be stable
+"""
+
+# ── Shared intake system prompt ───────────────────────────────────────────────
+# Identical to backend/models/google_client.py — GEMINI_INTAKE_SYSTEM.
+# Copied here so intake_eval is self-contained (no backend imports required).
+
+INTAKE_SYSTEM_PROMPT = """
+You are an intake analyst for an AI research roundtable. Your job is to
+analyze a user's prompt and make two decisions:
+
+1. CLARIFICATION: Does the prompt have enough context to produce a
+   high-quality research session?
+
+   - If the user's intent is ambiguous or a critical piece of context is
+     missing, set needs_clarification to true and provide ONE focused
+     clarifying question. Do not ask multiple questions.
+   - If the prompt is clear enough to proceed, set needs_clarification
+     to false and optimize the prompt directly.
+
+2. PROPER NOUN PRESERVATION (critical rule):
+
+   When the user provides specific proper nouns — model names, product
+   names, version numbers, company names, or any named entity — treat
+   them as correct and authoritative. Never substitute your own examples
+   or alternatives.
+
+   WRONG: User says "Claude Opus 4.7" → you ask "do you mean Claude 3 Opus?"
+   RIGHT: User says "Claude Opus 4.7" → you use "Claude Opus 4.7" exactly
+
+   WRONG: User says "GPT-5" → your clarifying question lists "GPT-4" as
+          an example of what they might mean
+   RIGHT: User says "GPT-5" → you use "GPT-5" exactly in all outputs
+
+   If you are uncertain whether a named entity exists, do NOT ask the user
+   to confirm using your own alternatives. Instead, ask about their INTENT
+   or SCOPE only — never suggest replacement names.
+
+3. TIER ASSIGNMENT: What research depth does this prompt require?
+
+   - quick : factual lookups, simple comparisons, gut checks.
+             Single-dimension questions with known answers.
+   - smart : analysis, recommendations, technical evaluations.
+             Requires weighing tradeoffs or synthesizing multiple sources.
+   - deep  : architecture decisions, strategic plans, critical reports.
+             High stakes, significant ambiguity, or complex dependencies.
+
+   Assign tier based on complexity and stakes — not prompt length.
+   A short prompt can require deep research.
+
+Always return valid JSON matching the schema exactly. No prose outside the
+JSON object.
+
+Required JSON schema:
+{
+  "needs_clarification": bool,
+  "clarifying_question": string or null,
+  "optimized_prompt": string,
+  "tier": "quick" | "smart" | "deep",
+  "output_type": string,
+  "reasoning": string
+}
+"""
+
+# ── Test definitions ──────────────────────────────────────────────────────────
+
+INTAKE_TESTS = [
+    {
+        "id":   "test1-simple",
+        "name": "Simple Research Question",
+        "description": (
+            "Clear, well-scoped research question. Should proceed without "
+            "clarification and assign smart tier."
+        ),
+        "prompt": (
+            "What are the main tradeoffs between PostgreSQL and MongoDB "
+            "for a mid-sized SaaS product with 100k users and a small "
+            "engineering team?"
+        ),
+        "turn2_input": None,  # single-turn test
+        "assertions": [
+            {
+                "name": "needs_clarification_false",
+                "field": "needs_clarification",
+                "expected": False,
+                "check": "equals",
+            },
+            {
+                "name": "tier_smart",
+                "field": "tier",
+                "expected": "smart",
+                "check": "equals",
+            },
+            {
+                "name": "optimized_prompt_nonempty",
+                "field": "optimized_prompt",
+                "expected": "",
+                "check": "nonempty",
+            },
+        ],
+    },
+    {
+        "id":   "test2-vague",
+        "name": "Vague Prompt (clarification required)",
+        "description": (
+            "Underspecified prompt — missing scope, domain, and context. "
+            "Should trigger clarification."
+        ),
+        "prompt": "How do I improve performance?",
+        "turn2_input": None,
+        "assertions": [
+            {
+                "name": "needs_clarification_true",
+                "field": "needs_clarification",
+                "expected": True,
+                "check": "equals",
+            },
+            {
+                "name": "clarifying_question_present",
+                "field": "clarifying_question",
+                "expected": "",
+                "check": "nonempty",
+            },
+            {
+                "name": "clarifying_question_single",
+                "field": "clarifying_question",
+                "expected": "?",
+                "check": "single_question",
+                "note": "Must ask exactly one question (one '?' or at most two closely related)",
+            },
+        ],
+    },
+    {
+        "id":   "test3-proper-nouns",
+        "name": "Proper Noun Preservation",
+        "description": (
+            "User provides specific model names that may not exist in the "
+            "model's training data. They must survive into the optimized_prompt "
+            "unchanged."
+        ),
+        "prompt": (
+            "Compare Claude Opus 4.7 and GPT-5 for enterprise coding assistant "
+            "use cases. Which handles multi-file refactoring better?"
+        ),
+        "turn2_input": None,
+        "assertions": [
+            {
+                "name": "needs_clarification_false",
+                "field": "needs_clarification",
+                "expected": False,
+                "check": "equals",
+            },
+            {
+                "name": "preserves_claude_opus_47",
+                "field": "optimized_prompt",
+                "expected": "Claude Opus 4.7",
+                "check": "contains",
+            },
+            {
+                "name": "preserves_gpt5",
+                "field": "optimized_prompt",
+                "expected": "GPT-5",
+                "check": "contains",
+            },
+            {
+                "name": "no_substitution_gpt4",
+                "field": "optimized_prompt",
+                "expected": "GPT-4",
+                "check": "not_contains",
+                "note": "Must not substitute GPT-4 for GPT-5",
+            },
+        ],
+    },
+    {
+        "id":   "test4a-tier-quick",
+        "name": "Tier Assignment — Quick",
+        "description": (
+            "Single-dimension factual lookup. Should assign quick tier."
+        ),
+        "prompt": (
+            "What is the current context window size for Gemini 2.5 Pro?"
+        ),
+        "turn2_input": None,
+        "assertions": [
+            {
+                "name": "tier_quick",
+                "field": "tier",
+                "expected": "quick",
+                "check": "equals",
+            },
+        ],
+    },
+    {
+        "id":   "test4b-tier-deep",
+        "name": "Tier Assignment — Deep",
+        "description": (
+            "High-stakes architecture decision with complexity and time pressure. "
+            "Should assign deep tier."
+        ),
+        "prompt": (
+            "I need a comprehensive architecture decision record for migrating "
+            "our monolith to microservices. We have 200k daily users, a team of "
+            "15 engineers, 4 years of technical debt, and a board presentation "
+            "in 6 weeks. The decision affects our next 3 years of infrastructure."
+        ),
+        "turn2_input": None,
+        "assertions": [
+            {
+                "name": "tier_deep",
+                "field": "tier",
+                "expected": "deep",
+                "check": "equals",
+            },
+        ],
+    },
+    {
+        "id":   "test5-two-turn",
+        "name": "Two-Turn: Proper Noun Preservation After Clarification",
+        "description": (
+            "Vague prompt triggers clarification. After user answers, the "
+            "optimized_prompt must preserve the original proper noun 'Claude "
+            "Opus 4.7' from the initial prompt."
+        ),
+        "prompt": (
+            "Help me evaluate Anthropic's Claude Opus 4.7 for our product. "
+            "We're not sure what use case fits best."
+        ),
+        "turn2_input": (
+            "We're building a coding assistant for mid-market software teams, "
+            "about 50 developers, writing mostly Python and TypeScript."
+        ),
+        "assertions": [
+            # Turn 0 assertions
+            {
+                "name": "t0_needs_clarification_true",
+                "field": "needs_clarification",
+                "expected": True,
+                "check": "equals",
+                "turn": 0,
+            },
+            # Turn 1 assertions (applied to turn2_result)
+            {
+                "name": "t1_needs_clarification_false",
+                "field": "needs_clarification",
+                "expected": False,
+                "check": "equals",
+                "turn": 1,
+            },
+            {
+                "name": "t1_preserves_claude_opus_47",
+                "field": "optimized_prompt",
+                "expected": "Claude Opus 4.7",
+                "check": "contains",
+                "turn": 1,
+            },
+        ],
+    },
+    {
+        "id":   "test6-consistency",
+        "name": "Tier Consistency (run 3x)",
+        "description": (
+            "Run the same borderline prompt three times. Tier assignment "
+            "must be stable — same value on all three runs."
+        ),
+        "prompt": (
+            "We're deciding whether to build our own RAG pipeline or buy a "
+            "vendor solution. Budget is $50k/year, team of 5 engineers, "
+            "need to go live in 3 months."
+        ),
+        "turn2_input": None,
+        "runs": 3,
+        "assertions": [
+            {
+                "name": "tier_stable",
+                "field": "tier",
+                "expected": None,   # filled after first run
+                "check": "consistent",
+                "note": "All 3 runs must return same tier",
+            },
+        ],
+    },
+]

--- a/experiments/intake_eval/run_eval.py
+++ b/experiments/intake_eval/run_eval.py
@@ -1,0 +1,745 @@
+"""
+experiments/intake_eval/run_eval.py
+
+Intake Model Evaluation Harness — token counting and automated scoring.
+========================================================================
+Tests five candidate intake models across six scenarios:
+  - clarification detection
+  - proper noun preservation
+  - tier assignment accuracy
+  - two-turn consistency
+  - cross-run stability
+
+Candidates:
+    - Gemini 2.5 Flash  (Google)     — current production model
+    - Gemini 2.0 Flash  (Google)     — previous generation baseline
+    - GPT-4o Mini       (OpenAI)     — cost-efficient cross-provider check
+    - Claude Haiku 4.5  (Anthropic)  — Anthropic's cost tier
+    - Qwen 2.5 72B      (OpenRouter) — open-weight cost baseline
+
+Usage:
+    cd /path/to/ai-roundtable
+    python -m experiments.intake_eval.run_eval
+
+Requirements:
+    API keys in backend/.env:
+        GOOGLE_API_KEY     — required for Gemini candidates
+        OPENAI_API_KEY     — required for GPT-4o Mini
+        ANTHROPIC_API_KEY  — required for Claude Haiku 4.5
+        OPENROUTER_API_KEY — required for Qwen 2.5 72B
+"""
+
+import os
+import sys
+import json
+import time
+from datetime import datetime
+from pathlib import Path
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+env_path = Path(__file__).parent.parent.parent / "backend" / ".env"
+if env_path.exists():
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip())
+
+repo_root = Path(__file__).parent.parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
+
+from experiments.intake_eval.prompts import (  # noqa: E402
+    INTAKE_SYSTEM_PROMPT, INTAKE_TESTS,
+)
+
+# ── Candidate registry ────────────────────────────────────────────────────────
+
+INTAKE_CANDIDATES = {
+    "Gemini-2.5-Flash": {
+        "provider":    "google",
+        "model":       "gemini-2.5-flash",
+        "input_rate":  0.15,
+        "output_rate": 0.60,
+        "label":       "Gemini 2.5 Flash (Google)",
+    },
+    "Gemini-2.0-Flash": {
+        "provider":    "google",
+        "model":       "gemini-2.0-flash",
+        "input_rate":  0.10,
+        "output_rate": 0.40,
+        "label":       "Gemini 2.0 Flash (Google)",
+    },
+    "GPT-4o-Mini": {
+        "provider":    "openai",
+        "model":       "gpt-4o-mini",
+        "input_rate":  0.15,
+        "output_rate": 0.60,
+        "label":       "GPT-4o Mini (OpenAI)",
+    },
+    "Claude-Haiku-4-5": {
+        "provider":    "anthropic",
+        "model":       "claude-haiku-4-5-20251001",
+        "input_rate":  0.80,
+        "output_rate": 4.00,
+        "label":       "Claude Haiku 4.5 (Anthropic)",
+    },
+    "Qwen-2.5-72B": {
+        "provider":    "openrouter",
+        "model":       "qwen/qwen-2.5-72b-instruct",
+        "input_rate":  0.40,
+        "output_rate": 1.20,
+        "label":       "Qwen 2.5 72B (OpenRouter)",
+    },
+}
+
+
+def _check_availability():
+    available = {}
+    google_ok     = False
+    openai_ok     = False
+    anthropic_ok  = False
+    openrouter_ok = False
+
+    try:
+        from google import genai as _g  # noqa: F401
+        if os.environ.get("GOOGLE_API_KEY"):
+            google_ok = True
+        else:
+            print("GOOGLE_API_KEY not set — skipping Gemini candidates")
+    except ImportError:
+        print("google-genai SDK not installed — skipping Gemini candidates")
+
+    try:
+        import openai  # noqa: F401
+        if os.environ.get("OPENAI_API_KEY"):
+            openai_ok = True
+        else:
+            print("OPENAI_API_KEY not set — skipping GPT-4o Mini")
+    except ImportError:
+        print("openai SDK not installed — skipping GPT-4o Mini")
+
+    try:
+        import anthropic  # noqa: F401
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            anthropic_ok = True
+        else:
+            print("ANTHROPIC_API_KEY not set — skipping Claude Haiku 4.5")
+    except ImportError:
+        print("anthropic SDK not installed — skipping Claude Haiku 4.5")
+
+    if os.environ.get("OPENROUTER_API_KEY"):
+        openrouter_ok = True
+    else:
+        print("OPENROUTER_API_KEY not set — skipping Qwen 2.5 72B")
+
+    for key, cfg in INTAKE_CANDIDATES.items():
+        p = cfg["provider"]
+        if p == "google" and google_ok:
+            available[key] = cfg
+        elif p == "openai" and openai_ok:
+            available[key] = cfg
+        elif p == "anthropic" and anthropic_ok:
+            available[key] = cfg
+        elif p == "openrouter" and openrouter_ok:
+            available[key] = cfg
+
+    return available
+
+
+AVAILABLE_CANDIDATES = _check_availability()
+
+# ── Cost helpers ──────────────────────────────────────────────────────────────
+
+def calculate_cost(input_tokens: int, output_tokens: int,
+                   input_rate: float, output_rate: float) -> float:
+    return (input_tokens / 1_000_000) * input_rate + \
+           (output_tokens / 1_000_000) * output_rate
+
+# ── API call functions ─────────────────────────────────────────────────────────
+# Each returns {"parsed": dict | None, "raw_text": str,
+#               "input_tokens": int, "output_tokens": int}
+
+def call_google_intake(prompt: str, model: str) -> dict:
+    from google import genai
+    from google.genai import types
+    import json as _json
+
+    client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+    config = types.GenerateContentConfig(
+        response_mime_type="application/json",
+        system_instruction=INTAKE_SYSTEM_PROMPT,
+        max_output_tokens=512,
+    )
+    response = client.models.generate_content(
+        model=model,
+        contents=[types.Content(
+            role="user",
+            parts=[types.Part(text=prompt)]
+        )],
+        config=config,
+    )
+    raw = response.text or ""
+    try:
+        parsed = _json.loads(raw)
+    except Exception:
+        parsed = None
+
+    usage = response.usage_metadata
+    return {
+        "parsed":        parsed,
+        "raw_text":      raw,
+        "input_tokens":  getattr(usage, "prompt_token_count", 0),
+        "output_tokens": getattr(usage, "candidates_token_count", 0),
+    }
+
+
+def call_openai_intake(prompt: str, model: str) -> dict:
+    import openai
+    import json as _json
+
+    client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    response = client.chat.completions.create(
+        model=model,
+        max_tokens=512,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": INTAKE_SYSTEM_PROMPT},
+            {"role": "user",   "content": prompt},
+        ],
+    )
+    raw = response.choices[0].message.content or ""
+    try:
+        parsed = _json.loads(raw)
+    except Exception:
+        parsed = None
+
+    return {
+        "parsed":        parsed,
+        "raw_text":      raw,
+        "input_tokens":  response.usage.prompt_tokens,
+        "output_tokens": response.usage.completion_tokens,
+    }
+
+
+def call_anthropic_intake(prompt: str, model: str) -> dict:
+    import anthropic
+    import json as _json
+
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    # Ask Claude to return only JSON
+    system = INTAKE_SYSTEM_PROMPT + (
+        "\n\nCRITICAL: Return ONLY the JSON object. "
+        "No preamble, no markdown fences, no trailing text."
+    )
+    response = client.messages.create(
+        model=model,
+        max_tokens=512,
+        system=system,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    raw = response.content[0].text or ""
+    # Strip markdown fences if present
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.split("```")[1]
+        if text.startswith("json"):
+            text = text[4:]
+    try:
+        parsed = _json.loads(text.strip())
+    except Exception:
+        parsed = None
+
+    return {
+        "parsed":        parsed,
+        "raw_text":      raw,
+        "input_tokens":  response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+    }
+
+
+def call_openrouter_intake(prompt: str, model: str) -> dict:
+    import httpx
+    import json as _json
+
+    headers = {
+        "Authorization": f"Bearer {os.environ['OPENROUTER_API_KEY']}",
+        "Content-Type":  "application/json",
+    }
+    payload = {
+        "model": model,
+        "max_tokens": 512,
+        "response_format": {"type": "json_object"},
+        "messages": [
+            {"role": "system", "content": INTAKE_SYSTEM_PROMPT},
+            {"role": "user",   "content": prompt},
+        ],
+    }
+    response = httpx.post(
+        "https://openrouter.ai/api/v1/chat/completions",
+        headers=headers,
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+    data   = response.json()
+    raw    = data["choices"][0]["message"]["content"] or ""
+    usage  = data.get("usage", {})
+    try:
+        parsed = _json.loads(raw)
+    except Exception:
+        parsed = None
+
+    return {
+        "parsed":        parsed,
+        "raw_text":      raw,
+        "input_tokens":  usage.get("prompt_tokens", 0),
+        "output_tokens": usage.get("completion_tokens", 0),
+    }
+
+
+def call_candidate(candidate_key: str, prompt: str) -> dict:
+    cfg = INTAKE_CANDIDATES[candidate_key]
+    if cfg["provider"] == "google":
+        return call_google_intake(prompt, cfg["model"])
+    elif cfg["provider"] == "openai":
+        return call_openai_intake(prompt, cfg["model"])
+    elif cfg["provider"] == "anthropic":
+        return call_anthropic_intake(prompt, cfg["model"])
+    elif cfg["provider"] == "openrouter":
+        return call_openrouter_intake(prompt, cfg["model"])
+    else:
+        return {"parsed": None, "raw_text": f"[Unknown provider: {cfg['provider']}]",
+                "input_tokens": 0, "output_tokens": 0}
+
+# ── Scoring ───────────────────────────────────────────────────────────────────
+
+def score_intake_result(parsed: dict | None, assertions: list,
+                        turn: int = 0) -> list[dict]:
+    """
+    Evaluate a parsed IntakeDecision against a list of assertion specs.
+    Returns list of {name, expected, actual, pass, note}.
+    """
+    if parsed is None:
+        # Parsing failed — all assertions fail
+        return [
+            {"name": a["name"], "expected": a.get("expected"), "actual": None,
+             "pass": False, "note": "JSON parse error"}
+            for a in assertions
+            if a.get("turn", 0) == turn
+        ]
+
+    results = []
+    for a in assertions:
+        if a.get("turn", 0) != turn:
+            continue
+
+        field    = a["field"]
+        expected = a.get("expected")
+        check    = a["check"]
+        actual   = parsed.get(field)
+        note     = a.get("note", "")
+
+        if check == "equals":
+            passed = actual == expected
+            results.append({"name": a["name"], "expected": expected,
+                             "actual": actual, "pass": passed, "note": note})
+
+        elif check == "nonempty":
+            passed = isinstance(actual, str) and len(actual.strip()) > 0
+            results.append({"name": a["name"], "expected": "non-empty string",
+                             "actual": (actual or "")[:80], "pass": passed,
+                             "note": note})
+
+        elif check == "contains":
+            passed = isinstance(actual, str) and expected in actual
+            results.append({"name": a["name"], "expected": f"contains '{expected}'",
+                             "actual": (actual or "")[:120], "pass": passed,
+                             "note": note})
+
+        elif check == "not_contains":
+            passed = isinstance(actual, str) and expected not in actual
+            results.append({"name": a["name"], "expected": f"does NOT contain '{expected}'",
+                             "actual": (actual or "")[:120], "pass": passed,
+                             "note": note})
+
+        elif check == "single_question":
+            # Rough check: no more than 2 question marks in the clarifying question
+            cq    = actual or ""
+            count = cq.count("?")
+            passed = 0 < count <= 2
+            results.append({"name": a["name"], "expected": "1-2 question marks",
+                             "actual": f"{count} '?' found in: {cq[:80]}",
+                             "pass": passed, "note": note})
+
+    return results
+
+
+def score_consistency(runs: list[dict | None]) -> dict:
+    """
+    Given a list of parsed results from multiple runs, check that the
+    'tier' field is the same across all runs.
+    Returns {stable: bool, tiers: list, majority_tier: str}.
+    """
+    tiers = []
+    for r in runs:
+        if r is not None:
+            tiers.append(r.get("tier", None))
+        else:
+            tiers.append(None)
+
+    unique = set(t for t in tiers if t is not None)
+    stable = len(unique) == 1 and None not in tiers
+    majority = max(set(tiers), key=tiers.count) if tiers else None
+    return {"stable": stable, "tiers": tiers, "majority_tier": majority}
+
+# ── Main evaluation ───────────────────────────────────────────────────────────
+
+def run_evaluation():
+    results_dir = Path(__file__).parent / "results"
+    results_dir.mkdir(exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    print(f"\n{'='*60}")
+    print("Intake Model Evaluation Harness — with cost analysis")
+    print(f"Candidates: {len(AVAILABLE_CANDIDATES)}")
+    print(f"Tests:      {len(INTAKE_TESTS)}")
+    print(f"{'='*60}\n")
+
+    if not AVAILABLE_CANDIDATES:
+        print("No candidates available. Check API keys in backend/.env.")
+        return
+
+    cost_data: dict = {}
+    all_results: dict = {}
+
+    for candidate_key, cfg in AVAILABLE_CANDIDATES.items():
+        print(f"\n── {cfg['label']} ──")
+        candidate_dir = results_dir / candidate_key
+        candidate_dir.mkdir(exist_ok=True)
+
+        all_results[candidate_key]   = {}
+        total_input_tokens  = 0
+        total_output_tokens = 0
+        total_cost          = 0.0
+        total_assertions    = 0
+        total_passes        = 0
+
+        for test in INTAKE_TESTS:
+            test_id = test["id"]
+            runs_n  = test.get("runs", 1)
+
+            print(f"  Running {test_id}...", end=" ", flush=True)
+
+            # ── Test 6: consistency across multiple runs ──────────────────────
+            if runs_n > 1:
+                run_results   = []
+                run_tokens_in = []
+                run_tokens_out= []
+                all_ok        = True
+                start         = time.time()
+
+                for run_idx in range(runs_n):
+                    try:
+                        r = call_candidate(candidate_key, test["prompt"])
+                        run_results.append(r["parsed"])
+                        run_tokens_in.append(r["input_tokens"])
+                        run_tokens_out.append(r["output_tokens"])
+                    except Exception as e:
+                        run_results.append(None)
+                        run_tokens_in.append(0)
+                        run_tokens_out.append(0)
+                        all_ok = False
+                    if run_idx < runs_n - 1:
+                        time.sleep(2)
+
+                elapsed       = round(time.time() - start, 1)
+                input_tokens  = sum(run_tokens_in)
+                output_tokens = sum(run_tokens_out)
+                consistency   = score_consistency(run_results)
+                status        = "✓" if all_ok else "✗"
+
+                test_cost = calculate_cost(input_tokens, output_tokens,
+                                           cfg["input_rate"], cfg["output_rate"])
+                total_input_tokens  += input_tokens
+                total_output_tokens += output_tokens
+                total_cost          += test_cost
+
+                assertion_result = {
+                    "name":      "tier_stable",
+                    "expected":  "same tier on all 3 runs",
+                    "actual":    str(consistency["tiers"]),
+                    "pass":      consistency["stable"],
+                    "note":      f"majority tier: {consistency['majority_tier']}",
+                }
+                total_assertions += 1
+                if consistency["stable"]:
+                    total_passes += 1
+
+                print(f"{status} ({elapsed}s | {input_tokens}in+{output_tokens}out "
+                      f"| ${test_cost:.5f}) — tier stable: {consistency['stable']} "
+                      f"{consistency['tiers']}")
+
+                all_results[candidate_key][test_id] = {
+                    "runs":              [r for r in run_results],
+                    "consistency":       consistency,
+                    "assertion":         assertion_result,
+                    "input_tokens":      input_tokens,
+                    "output_tokens":     output_tokens,
+                    "cost":              round(test_cost, 6),
+                    "status":            status,
+                    "elapsed":           elapsed,
+                }
+
+                # Write result file
+                result_path = candidate_dir / f"{test_id}.md"
+                with open(result_path, "w") as f:
+                    f.write(f"# {cfg['label']} — {test['name']}\n\n")
+                    f.write(f"**Generated:** {timestamp}\n")
+                    f.write(f"**Elapsed:** {elapsed}s ({runs_n} runs)\n")
+                    f.write(f"**Tokens:** {input_tokens} input / "
+                            f"{output_tokens} output (total)\n")
+                    f.write(f"**Cost:** ${test_cost:.6f}\n\n")
+                    f.write("## Consistency Check\n\n")
+                    icon = "✓" if consistency["stable"] else "✗"
+                    f.write(f"- {icon} Tier stable across {runs_n} runs: "
+                            f"{consistency['tiers']}\n")
+                    f.write(f"- Majority tier: **{consistency['majority_tier']}**\n\n")
+                    f.write("## Raw Outputs per Run\n\n")
+                    for i, r in enumerate(run_results):
+                        f.write(f"### Run {i+1}\n\n")
+                        f.write("```json\n")
+                        f.write(json.dumps(r, indent=2) if r else "(parse error)")
+                        f.write("\n```\n\n")
+
+                time.sleep(1)
+                continue
+
+            # ── Single-turn or two-turn tests ────────────────────────────────
+            try:
+                start  = time.time()
+                turn0  = call_candidate(candidate_key, test["prompt"])
+                elapsed = round(time.time() - start, 1)
+                status  = "✓"
+                input_tokens  = turn0["input_tokens"]
+                output_tokens = turn0["output_tokens"]
+            except Exception as e:
+                turn0   = {"parsed": None, "raw_text": f"[ERROR: {e}]",
+                           "input_tokens": 0, "output_tokens": 0}
+                elapsed = 0.0
+                status  = "✗"
+                input_tokens  = 0
+                output_tokens = 0
+
+            turn1 = None
+            if test.get("turn2_input") and (
+                turn0["parsed"] is not None and
+                turn0["parsed"].get("needs_clarification") is True
+            ):
+                # Build combined Turn 1 prompt (mirrors backend/intake.py)
+                cq = (turn0["parsed"].get("clarifying_question") or
+                      "(no question returned)")
+                combined = (
+                    f"Original prompt: {test['prompt']}\n"
+                    f"Clarifying question asked: {cq}\n"
+                    f"User's answer: {test['turn2_input']}\n\n"
+                    "Now return the final IntakeDecision with "
+                    "needs_clarification: false. "
+                    "IMPORTANT: The optimized_prompt must preserve all proper "
+                    "nouns from the original prompt exactly as written. Do not "
+                    "substitute model names, product names, or version numbers."
+                )
+                try:
+                    time.sleep(1)
+                    turn1 = call_candidate(candidate_key, combined)
+                    input_tokens  += turn1["input_tokens"]
+                    output_tokens += turn1["output_tokens"]
+                except Exception as e:
+                    turn1 = {"parsed": None, "raw_text": f"[ERROR: {e}]",
+                             "input_tokens": 0, "output_tokens": 0}
+
+            test_cost = calculate_cost(input_tokens, output_tokens,
+                                       cfg["input_rate"], cfg["output_rate"])
+            total_input_tokens  += input_tokens
+            total_output_tokens += output_tokens
+            total_cost          += test_cost
+
+            # Score assertions
+            assertions = test["assertions"]
+            turn0_results = score_intake_result(turn0["parsed"], assertions, turn=0)
+            turn1_results = []
+            if turn1 is not None:
+                turn1_results = score_intake_result(
+                    turn1["parsed"], assertions, turn=1
+                )
+
+            all_assertion_results = turn0_results + turn1_results
+            test_passes = sum(1 for a in all_assertion_results if a["pass"])
+            test_total  = len(all_assertion_results)
+            total_assertions += test_total
+            total_passes     += test_passes
+
+            pct = int(test_passes / test_total * 100) if test_total else 0
+            print(f"{status} ({elapsed}s | {input_tokens}in+{output_tokens}out "
+                  f"| ${test_cost:.5f}) — {test_passes}/{test_total} assertions")
+
+            all_results[candidate_key][test_id] = {
+                "turn0":          turn0["parsed"],
+                "turn1":          turn1["parsed"] if turn1 else None,
+                "assertions":     all_assertion_results,
+                "passes":         test_passes,
+                "total":          test_total,
+                "input_tokens":   input_tokens,
+                "output_tokens":  output_tokens,
+                "cost":           round(test_cost, 6),
+                "status":         status,
+                "elapsed":        elapsed,
+            }
+
+            # Write result file
+            result_path = candidate_dir / f"{test_id}.md"
+            with open(result_path, "w") as f:
+                f.write(f"# {cfg['label']} — {test['name']}\n\n")
+                f.write(f"**Generated:** {timestamp}\n")
+                f.write(f"**Description:** {test['description']}\n")
+                f.write(f"**Elapsed:** {elapsed}s\n")
+                f.write(f"**Tokens:** {input_tokens} input / "
+                        f"{output_tokens} output\n")
+                f.write(f"**Cost:** ${test_cost:.6f}\n\n")
+                f.write(f"## Assertions — {test_passes}/{test_total} passed\n\n")
+                for ar in all_assertion_results:
+                    icon = "✓" if ar["pass"] else "✗"
+                    f.write(f"- {icon} **{ar['name']}**  \n")
+                    f.write(f"  Expected: `{ar['expected']}`  \n")
+                    f.write(f"  Actual: `{ar['actual']}`")
+                    if ar.get("note"):
+                        f.write(f"  _{ar['note']}_")
+                    f.write("\n\n")
+                f.write("## Turn 0 Output\n\n```json\n")
+                f.write(json.dumps(turn0["parsed"], indent=2)
+                        if turn0["parsed"] else turn0["raw_text"])
+                f.write("\n```\n\n")
+                if turn1 is not None:
+                    f.write("## Turn 1 Output\n\n```json\n")
+                    f.write(json.dumps(turn1["parsed"], indent=2)
+                            if turn1["parsed"] else turn1["raw_text"])
+                    f.write("\n```\n\n")
+
+            time.sleep(1)
+
+        # Per-candidate cost summary
+        avg_in  = total_input_tokens  / max(len(INTAKE_TESTS), 1)
+        avg_out = total_output_tokens / max(len(INTAKE_TESTS), 1)
+        per_session_cost = calculate_cost(avg_in, avg_out,
+                                          cfg["input_rate"], cfg["output_rate"])
+        overall_pct = (total_passes / total_assertions * 100
+                       if total_assertions else 0)
+
+        cost_data[candidate_key] = {
+            "label":               cfg["label"],
+            "model":               cfg["model"],
+            "input_rate":          cfg["input_rate"],
+            "output_rate":         cfg["output_rate"],
+            "total_input_tokens":  total_input_tokens,
+            "total_output_tokens": total_output_tokens,
+            "total_cost_6tests":   round(total_cost, 6),
+            "avg_input_tokens":    round(avg_in, 1),
+            "avg_output_tokens":   round(avg_out, 1),
+            "assertion_pass_pct":  round(overall_pct, 1),
+            "per_session_cost":    round(per_session_cost, 7),
+            "100_sessions":        round(per_session_cost * 100, 4),
+            "1k_sessions":         round(per_session_cost * 1_000, 3),
+            "10k_sessions":        round(per_session_cost * 10_000, 2),
+        }
+
+        print(f"  ── Totals: {total_input_tokens} in / {total_output_tokens} out "
+              f"| ${total_cost:.5f} for {len(INTAKE_TESTS)} tests")
+        print(f"  ── Per session: ${per_session_cost:.7f} | "
+              f"1K sessions: ${cost_data[candidate_key]['1k_sessions']:.3f}")
+        print(f"  ── Assertions: {total_passes}/{total_assertions} "
+              f"({overall_pct:.0f}%)")
+
+    # ── Save cost_data.json ───────────────────────────────────────────────────
+    cost_json_path = results_dir / f"cost_data-{timestamp}.json"
+    with open(cost_json_path, "w") as f:
+        json.dump({"timestamp": timestamp, "candidates": cost_data}, f, indent=2)
+
+    # ── Write summary markdown ────────────────────────────────────────────────
+    summary_path = results_dir / f"summary-{timestamp}.md"
+    with open(summary_path, "w") as f:
+        f.write("# Intake Model Evaluation Summary\n\n")
+        f.write(f"**Date:** {timestamp}\n")
+        f.write(f"**Candidates tested:** {len(AVAILABLE_CANDIDATES)}\n\n")
+
+        f.write("## Results Matrix\n\n")
+        header = "| Candidate |"
+        sep    = "|-----------|"
+        for test in INTAKE_TESTS:
+            header += f" {test['id']} |"
+            sep    += "---------|"
+        header += " Assert% | $/session | $/1K |\n"
+        sep    += "---------|----------|------|\n"
+        f.write(header)
+        f.write(sep)
+
+        for ck in AVAILABLE_CANDIDATES:
+            row = f"| {cost_data[ck]['label']} |"
+            for test in INTAKE_TESTS:
+                tr = all_results[ck].get(test["id"], {})
+                s  = tr.get("status", "?")
+                row += f" {s} |"
+            cd = cost_data[ck]
+            row += (f" {cd['assertion_pass_pct']}% |"
+                    f" ${cd['per_session_cost']:.6f} |"
+                    f" ${cd['1k_sessions']:.3f} |\n")
+            f.write(row)
+
+        f.write("\n## Cost Analysis\n\n")
+        f.write("| Candidate | $/session | 100 sessions | 1K sessions | "
+                "10K sessions |\n")
+        f.write("|-----------|----------|-------------|------------|"
+                "-------------|\n")
+        for ck, cd in cost_data.items():
+            f.write(f"| {cd['label']} | ${cd['per_session_cost']:.6f} | "
+                    f"${cd['100_sessions']:.4f} | "
+                    f"${cd['1k_sessions']:.3f} | "
+                    f"${cd['10k_sessions']:.2f} |\n")
+
+        f.write("\n## Assertion Detail by Test\n\n")
+        for test in INTAKE_TESTS:
+            f.write(f"### {test['name']}\n\n")
+            f.write(f"_{test['description']}_\n\n")
+            for ck in AVAILABLE_CANDIDATES:
+                tr = all_results[ck].get(test["id"], {})
+                f.write(f"**{cost_data[ck]['label']}**\n\n")
+                if "assertions" in tr:
+                    for ar in tr["assertions"]:
+                        icon = "✓" if ar["pass"] else "✗"
+                        f.write(f"- {icon} {ar['name']}: `{ar['actual']}`\n")
+                elif "consistency" in tr:
+                    c = tr["consistency"]
+                    icon = "✓" if c["stable"] else "✗"
+                    f.write(f"- {icon} tier stable: {c['stable']} "
+                            f"— {c['tiers']}\n")
+                f.write("\n")
+
+        f.write("## Next Steps\n\n")
+        f.write("1. Read per-candidate result files in `results/<candidate>/`\n")
+        f.write("2. Review proper noun tests — any substitution is a fail\n")
+        f.write("3. Document decision in `docs/decisions/003-intake-model-"
+                "selection.md`\n")
+        f.write(f"\nCost data JSON: {cost_json_path}\n")
+
+    print(f"\n{'='*60}")
+    print("Evaluation complete.")
+    print(f"Results:   {results_dir}")
+    print(f"Summary:   {summary_path}")
+    print(f"Cost JSON: {cost_json_path}")
+    print(f"{'='*60}\n")
+
+
+if __name__ == "__main__":
+    run_evaluation()

--- a/experiments/synthesizer_eval/README.md
+++ b/experiments/synthesizer_eval/README.md
@@ -4,14 +4,15 @@ Empirical evaluation of candidate models for the ai-roundtable synthesis role.
 
 ## Why This Exists
 
-Claude (the default synthesizer) fails on queries where Perplexity's live
-web research contradicts round-1 model responses on verifiable current facts.
-Claude's trained refusal behavior for post-cutoff data overrides system prompt
-instructions — it treats Perplexity's cited live-web data as unreliable rather
-than authoritative.
+Claude (the default synthesizer) has a failure mode on queries where
+Perplexity's live web research contradicts round-1 model responses on
+verifiable current facts. Claude's trained refusal behavior for post-cutoff
+data was overriding system prompt instructions — it treated Perplexity's
+cited live-web data as unreliable rather than authoritative.
 
-This harness tests whether alternative models handle this better while
-maintaining synthesis quality on analytical questions.
+This harness tests whether the updated trust hierarchy (three-tier, "PERPLEXITY
+WINS") resolves the failure, and benchmarks alternative synthesizer candidates
+for cost and quality comparison.
 
 ## How to Run
 
@@ -20,17 +21,17 @@ maintaining synthesis quality on analytical questions.
 cd /path/to/ai-roundtable
 
 # Ensure API keys are in backend/.env
-# Required: ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY
-# Optional: OPENROUTER_API_KEY (for DeepSeek, Qwen, Llama)
+# Required: ANTHROPIC_API_KEY (Claude candidates), OPENAI_API_KEY (GPT-4o)
+# Optional: OPENROUTER_API_KEY (Qwen 2.5 72B)
 
-python -m experiments.synthesizer-eval.run_eval
+python -m experiments.synthesizer_eval.run_eval
 ```
 
 ## How to Read Results
 
-Results are saved to `experiments/synthesizer-eval/results/` — one folder
-per candidate, one markdown file per test. A timestamped `summary-*.md`
-is written with the results matrix and scoring rubric.
+Results are saved to `experiments/synthesizer_eval/results/` (gitignored) —
+one folder per candidate, one markdown file per test. A timestamped
+`summary-*.md` and `cost_data-*.json` are written.
 
 The three tests stress different synthesizer capabilities:
 
@@ -47,8 +48,8 @@ Key assertions:
 
 **Test 2 — Analytical Synthesis (the working case)**
 Pure analysis with model disagreement and no post-cutoff data gap. Tests
-synthesis quality on opinions and tradeoffs — where Claude currently excels.
-Used to confirm alternative models don't regress on the core task.
+synthesis quality on opinions and tradeoffs — where all models generally
+perform well. Used to confirm no regression on the core task.
 
 **Test 3 — Domain Technical (the showcase case)**
 ISO-NE offshore wind capacity accreditation. Tests terminology correction
@@ -58,24 +59,43 @@ and attributes the correction.
 
 ## Scoring
 
-Score each candidate using the rubric in `prompts.py` (also written to
-`results/summary-*.md`). Six dimensions, 1-5 each, total max 30 points.
+Six dimensions, 1–5 each, total max 30 points per test (90 total):
+
+1. **Factual grounding** — uses Perplexity's verified data as primary source
+2. **Attribution** — every claim attributed to a named source
+3. **Contradiction handling** — states conflicts explicitly, does not blend
+4. **Analytical depth** — adds expert perspective beyond summarizing
+5. **Tag adoption** — uses `[VERIFIED]`/`[LIKELY]`/`[UNCERTAIN]`/`[DEFER]`
+6. **Actionability** — ends with 3 concrete actionable next steps
 
 Critical failure conditions on Test 1:
 - Calls Perplexity's live-cited data "fabricated"
 - Refuses to incorporate post-cutoff data when Perplexity has verified it
 - Presents a retired model's pricing as current
 
-## Candidates
+## Candidates (v2)
 
-| Candidate | Provider | Key Required |
-|-----------|----------|-------------|
-| Claude Opus 4.7 | Anthropic | `ANTHROPIC_API_KEY` |
-| GPT-4o | OpenAI | `OPENAI_API_KEY` |
-| Gemini 2.5 Pro | Google | `GOOGLE_API_KEY` |
-| DeepSeek V3 | OpenRouter | `OPENROUTER_API_KEY` |
-| Qwen 2.5 72B | OpenRouter | `OPENROUTER_API_KEY` |
-| Llama 3.3 70B | OpenRouter | `OPENROUTER_API_KEY` |
+| Candidate | Provider | Key Required | Role |
+|-----------|----------|-------------|------|
+| Claude Opus 4.7 | Anthropic | `ANTHROPIC_API_KEY` | Deep tier baseline |
+| Claude Sonnet 4.6 | Anthropic | `ANTHROPIC_API_KEY` | Smart tier candidate |
+| Claude Haiku 4.5 | Anthropic | `ANTHROPIC_API_KEY` | Quick tier candidate |
+| GPT-4o | OpenAI | `OPENAI_API_KEY` | Cross-provider benchmark |
+| Qwen 2.5 72B | OpenRouter | `OPENROUTER_API_KEY` | Open-weight cost baseline |
+
+## Cost Analysis
+
+Token counts and costs are recorded per call. The summary includes:
+- Per-candidate token profile (avg input / output tokens)
+- Monthly projection at 100 / 1K / 10K sessions
+- Tier-routing scenario (60% Quick / 30% Smart / 10% Deep)
+- Automated pass criteria check percentage
+
+To generate the combined cost report (requires both synthesizer and intake
+evals to have run):
+```bash
+python -m experiments.generate_cost_report
+```
 
 ## Decision Record
 

--- a/experiments/synthesizer_eval/run_eval.py
+++ b/experiments/synthesizer_eval/run_eval.py
@@ -1,35 +1,37 @@
 """
-experiments/synthesizer-eval/run_eval.py
+experiments/synthesizer_eval/run_eval.py
 
-Synthesizer Evaluation Harness
-================================
-Runs three fixed test prompts through multiple synthesizer candidates.
+Synthesizer Evaluation Harness v2 — token counting and cost analysis.
+======================================================================
+Runs three fixed test prompts through five synthesizer candidates.
 Each candidate receives identical input. Outputs saved to results/.
+
+Candidates:
+    - Claude Opus 4.7  (Anthropic)  — baseline, highest quality
+    - Claude Sonnet 4.6 (Anthropic) — Smart tier candidate
+    - Claude Haiku 4.5 (Anthropic)  — Quick tier candidate
+    - GPT-4o           (OpenAI)     — cross-provider benchmark
+    - Qwen 2.5 72B     (OpenRouter) — open-weight cost baseline
 
 Usage:
     cd /path/to/ai-roundtable
-    python -m experiments.synthesizer-eval.run_eval
+    python -m experiments.synthesizer_eval.run_eval
 
 Requirements:
-    API keys in backend/.env for each candidate you want to test.
-    OPENROUTER_API_KEY required for open-weight models.
-
-Candidates tested:
-    - Claude Opus 4.7 (Anthropic)
-    - GPT-4o (OpenAI)
-    - Gemini 2.5 Pro (Google)
-    - DeepSeek V3 (via OpenRouter, if key available)
-    - Qwen 2.5 72B (via OpenRouter, if key available)
-    - Llama 3.3 70B (via OpenRouter, if key available)
+    API keys in backend/.env:
+        ANTHROPIC_API_KEY  — required for Claude candidates
+        OPENAI_API_KEY     — required for GPT-4o
+        OPENROUTER_API_KEY — required for Qwen 2.5 72B
 """
 
 import os
 import sys
+import json
 import time
 from datetime import datetime
 from pathlib import Path
 
-# Load .env from backend/
+# ── Load .env from backend/ ───────────────────────────────────────────────────
 env_path = Path(__file__).parent.parent.parent / "backend" / ".env"
 if env_path.exists():
     with open(env_path) as f:
@@ -40,7 +42,7 @@ if env_path.exists():
             k, _, v = line.partition("=")
             os.environ.setdefault(k.strip(), v.strip())
 
-# Insert repo root so `from backend.` imports work when run as a module
+# ── Insert repo root for imports ──────────────────────────────────────────────
 repo_root = Path(__file__).parent.parent.parent
 if str(repo_root) not in sys.path:
     sys.path.insert(0, str(repo_root))
@@ -52,44 +54,98 @@ from experiments.synthesizer_eval.prompts import (  # noqa: E402
     SCORING_RUBRIC,
 )
 
-# ── Discover available candidates ─────────────────────────────────────────────
+# ── Candidate registry ────────────────────────────────────────────────────────
+# input_rate / output_rate: USD per 1M tokens
 
-AVAILABLE_CANDIDATES = {}
+SYNTHESIZER_CANDIDATES = {
+    "Claude-Opus-4-7": {
+        "provider":    "anthropic",
+        "model":       "claude-opus-4-7",
+        "input_rate":  5.00,
+        "output_rate": 25.00,
+        "label":       "Claude Opus 4.7 (Anthropic)",
+    },
+    "Claude-Sonnet-4-6": {
+        "provider":    "anthropic",
+        "model":       "claude-sonnet-4-6",
+        "input_rate":  3.00,
+        "output_rate": 15.00,
+        "label":       "Claude Sonnet 4.6 (Anthropic)",
+    },
+    "Claude-Haiku-4-5": {
+        "provider":    "anthropic",
+        "model":       "claude-haiku-4-5-20251001",
+        "input_rate":  0.80,
+        "output_rate": 4.00,
+        "label":       "Claude Haiku 4.5 (Anthropic)",
+    },
+    "GPT-4o": {
+        "provider":    "openai",
+        "model":       "gpt-4o",
+        "input_rate":  2.50,
+        "output_rate": 10.00,
+        "label":       "GPT-4o (OpenAI)",
+    },
+    "Qwen-2.5-72B": {
+        "provider":    "openrouter",
+        "model":       "qwen/qwen-2.5-72b-instruct",
+        "input_rate":  0.40,
+        "output_rate": 1.20,
+        "label":       "Qwen 2.5 72B (OpenRouter)",
+    },
+}
 
-try:
-    import anthropic  # noqa: F401
-    if os.environ.get("ANTHROPIC_API_KEY"):
-        AVAILABLE_CANDIDATES["Claude (claude-opus-4-7)"] = "anthropic"
+# ── Availability check ────────────────────────────────────────────────────────
+
+def _check_availability():
+    available = {}
+    anthropic_ok = False
+    openai_ok = False
+    openrouter_ok = False
+
+    try:
+        import anthropic  # noqa: F401
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            anthropic_ok = True
+        else:
+            print("ANTHROPIC_API_KEY not set — skipping Claude candidates")
+    except ImportError:
+        print("anthropic SDK not installed — skipping Claude candidates")
+
+    try:
+        import openai  # noqa: F401
+        if os.environ.get("OPENAI_API_KEY"):
+            openai_ok = True
+        else:
+            print("OPENAI_API_KEY not set — skipping GPT-4o")
+    except ImportError:
+        print("openai SDK not installed — skipping GPT-4o")
+
+    if os.environ.get("OPENROUTER_API_KEY"):
+        openrouter_ok = True
     else:
-        print("ANTHROPIC_API_KEY not set — skipping Claude")
-except ImportError:
-    print("anthropic SDK not installed — skipping Claude")
+        print("OPENROUTER_API_KEY not set — skipping Qwen 2.5 72B")
 
-try:
-    import openai  # noqa: F401
-    if os.environ.get("OPENAI_API_KEY"):
-        AVAILABLE_CANDIDATES["GPT-4o (openai)"] = "openai"
-    else:
-        print("OPENAI_API_KEY not set — skipping GPT-4o")
-except ImportError:
-    print("openai SDK not installed — skipping GPT-4o")
+    for key, cfg in SYNTHESIZER_CANDIDATES.items():
+        p = cfg["provider"]
+        if p == "anthropic" and anthropic_ok:
+            available[key] = cfg
+        elif p == "openai" and openai_ok:
+            available[key] = cfg
+        elif p == "openrouter" and openrouter_ok:
+            available[key] = cfg
 
-try:
-    from google import genai as _genai  # noqa: F401
-    if os.environ.get("GOOGLE_API_KEY"):
-        AVAILABLE_CANDIDATES["Gemini 2.5 Pro (google)"] = "google"
-    else:
-        print("GOOGLE_API_KEY not set — skipping Gemini")
-except ImportError:
-    print("google-genai SDK not installed — skipping Gemini")
+    return available
 
-if os.environ.get("OPENROUTER_API_KEY"):
-    AVAILABLE_CANDIDATES["DeepSeek-V3 (openrouter)"] = "openrouter_deepseek"
-    AVAILABLE_CANDIDATES["Qwen2.5-72B (openrouter)"] = "openrouter_qwen"
-    AVAILABLE_CANDIDATES["Llama-3.3-70B (openrouter)"] = "openrouter_llama"
-else:
-    print("OPENROUTER_API_KEY not set — skipping DeepSeek, Qwen, Llama")
-    print("Add OPENROUTER_API_KEY to backend/.env to include open-weight models")
+AVAILABLE_CANDIDATES = _check_availability()
+
+# ── Cost helpers ──────────────────────────────────────────────────────────────
+
+def calculate_cost(input_tokens: int, output_tokens: int,
+                   input_rate: float, output_rate: float) -> float:
+    """Return cost in USD given token counts and per-MTok rates."""
+    return (input_tokens / 1_000_000) * input_rate + \
+           (output_tokens / 1_000_000) * output_rate
 
 # ── Synthesis system prompt ───────────────────────────────────────────────────
 
@@ -134,68 +190,54 @@ do not blend.
 - End with 3 concrete actionable next steps
 """
 
-# ── Call functions per provider ───────────────────────────────────────────────
+# ── API call functions — return {text, input_tokens, output_tokens} ───────────
 
-def call_anthropic(user_message: str, system: str) -> str:
+def call_anthropic(user_message: str, system: str, model: str) -> dict:
     import anthropic
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
     response = client.messages.create(
-        model="claude-opus-4-7",
+        model=model,
         max_tokens=2000,
         system=system,
         messages=[{"role": "user", "content": user_message}],
     )
-    return response.content[0].text
+    return {
+        "text":          response.content[0].text,
+        "input_tokens":  response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+    }
 
 
-def call_openai(user_message: str, system: str) -> str:
+def call_openai(user_message: str, system: str, model: str) -> dict:
     import openai
     client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
     response = client.chat.completions.create(
-        model="gpt-4o",
+        model=model,
         max_tokens=2000,
         messages=[
             {"role": "system", "content": system},
             {"role": "user", "content": user_message},
         ],
     )
-    return response.choices[0].message.content
+    return {
+        "text":          response.choices[0].message.content,
+        "input_tokens":  response.usage.prompt_tokens,
+        "output_tokens": response.usage.completion_tokens,
+    }
 
 
-def call_google(user_message: str, system: str) -> str:
-    from google import genai
-    from google.genai import types
-    client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
-    response = client.models.generate_content(
-        model="gemini-2.5-pro",
-        contents=[types.Content(role="user", parts=[types.Part(text=user_message)])],
-        config=types.GenerateContentConfig(
-            max_output_tokens=2000,
-            system_instruction=system,
-        ),
-    )
-    return response.text
-
-
-OPENROUTER_MODEL_IDS = {
-    "openrouter_deepseek": "deepseek/deepseek-chat-v3-0324",
-    "openrouter_qwen":     "qwen/qwen-2.5-72b-instruct",
-    "openrouter_llama":    "meta-llama/llama-3.3-70b-instruct",
-}
-
-
-def call_openrouter(user_message: str, system: str, model_id: str) -> str:
+def call_openrouter(user_message: str, system: str, model: str) -> dict:
     import httpx
     headers = {
         "Authorization": f"Bearer {os.environ['OPENROUTER_API_KEY']}",
-        "Content-Type": "application/json",
+        "Content-Type":  "application/json",
     }
     payload = {
-        "model": model_id,
+        "model": model,
         "max_tokens": 2000,
         "messages": [
             {"role": "system", "content": system},
-            {"role": "user", "content": user_message},
+            {"role": "user",   "content": user_message},
         ],
     }
     response = httpx.post(
@@ -205,26 +247,31 @@ def call_openrouter(user_message: str, system: str, model_id: str) -> str:
         timeout=60,
     )
     response.raise_for_status()
-    return response.json()["choices"][0]["message"]["content"]
+    data = response.json()
+    usage = data.get("usage", {})
+    return {
+        "text":          data["choices"][0]["message"]["content"],
+        "input_tokens":  usage.get("prompt_tokens", 0),
+        "output_tokens": usage.get("completion_tokens", 0),
+    }
 
 
-def call_candidate(candidate_key: str, user_message: str, system: str) -> str:
-    provider = AVAILABLE_CANDIDATES[candidate_key]
-    if provider == "anthropic":
-        return call_anthropic(user_message, system)
-    elif provider == "openai":
-        return call_openai(user_message, system)
-    elif provider == "google":
-        return call_google(user_message, system)
-    elif provider.startswith("openrouter_"):
-        model_id = OPENROUTER_MODEL_IDS[provider]
-        return call_openrouter(user_message, system, model_id)
+def call_candidate(candidate_key: str, user_message: str, system: str) -> dict:
+    cfg = SYNTHESIZER_CANDIDATES[candidate_key]
+    if cfg["provider"] == "anthropic":
+        return call_anthropic(user_message, system, cfg["model"])
+    elif cfg["provider"] == "openai":
+        return call_openai(user_message, system, cfg["model"])
+    elif cfg["provider"] == "openrouter":
+        return call_openrouter(user_message, system, cfg["model"])
     else:
-        return f"[Unknown provider: {provider}]"
+        return {"text": f"[Unknown provider: {cfg['provider']}]",
+                "input_tokens": 0, "output_tokens": 0}
 
-# ── Build user message for synthesis ─────────────────────────────────────────
+# ── User message builder ──────────────────────────────────────────────────────
 
-def build_user_message(user_prompt: str, round1: dict, perplexity: str) -> str:
+def build_user_message(user_prompt: str, round1: dict,
+                       perplexity: str) -> str:
     round1_block = "\n\n".join(
         f"### {model}\n{response}"
         for model, response in round1.items()
@@ -244,15 +291,75 @@ Synthesize the above into a comprehensive response to the user's question.
 Follow the Source Trust Hierarchy in your system prompt exactly.
 """
 
+# ── Automated pass criteria check ─────────────────────────────────────────────
+
+def auto_check_criteria(output: str, criteria: list[str]) -> list[dict]:
+    """
+    Rough automated check: look for key phrases from each criterion in output.
+    NOT a substitute for the full rubric — used for quick cost-report estimates.
+    """
+    results = []
+    output_lower = output.lower()
+    for criterion in criteria:
+        # Extract key nouns/phrases from criterion for keyword matching
+        # Heuristic: look for quoted strings or specific terms
+        keywords = []
+        if "$5" in criterion or "$5/$25" in criterion:
+            keywords = ["$5", "5/25", "5 / 25"]
+        elif "$15/$75" in criterion or "15/75" in criterion:
+            # Must NOT appear as current — check inverse
+            found = "$15" in output or "15/75" in output.replace(" ", "")
+            results.append({"criterion": criterion[:80], "pass": not found,
+                            "note": "inverse check"})
+            continue
+        elif "retirement" in criterion.lower() or "retire" in criterion.lower():
+            keywords = ["retire", "deprecat", "jan 5, 2026", "january 5"]
+        elif "fabricat" in criterion.lower():
+            # Must NOT call Perplexity fabricated
+            found = "fabricat" in output_lower
+            results.append({"criterion": criterion[:80], "pass": not found,
+                            "note": "inverse check"})
+            continue
+        elif "dpo" in criterion.lower():
+            keywords = ["dpo"]
+        elif "attribut" in criterion.lower():
+            keywords = ["according to", "claude said", "gemini said",
+                        "gpt said", "notes that", "suggests"]
+        elif "actionable" in criterion.lower() or "next step" in criterion.lower():
+            keywords = ["next step", "action", "recommend", "start with"]
+        elif "rca" in criterion.lower() or "raa" in criterion.lower():
+            keywords = ["rca", "raa", "qmric"]
+        elif "mri" in criterion.lower() and "gemini" in criterion.lower():
+            keywords = ["gemini", "mri", "incorrect", "incorrect term",
+                        "wrong", "standard"]
+        elif "dnv" in criterion.lower():
+            keywords = ["dnv"]
+        elif "phase" in criterion.lower():
+            keywords = ["phase 1", "phase 2"]
+        else:
+            # Generic: look for any significant word (>5 chars) from criterion
+            words = [w.lower() for w in criterion.split()
+                     if len(w) > 5 and w.isalpha()]
+            keywords = words[:3]
+
+        if keywords:
+            found = any(kw.lower() in output_lower for kw in keywords)
+            results.append({"criterion": criterion[:80], "pass": found,
+                            "note": "keyword: " + ", ".join(keywords[:2])})
+        else:
+            results.append({"criterion": criterion[:80], "pass": None,
+                            "note": "no keywords extracted"})
+    return results
+
 # ── Test definitions ──────────────────────────────────────────────────────────
 
 TESTS = [
     {
-        "id": "test1-factual",
+        "id":   "test1-factual",
         "name": "Factual Current Data (the failing case)",
         "user_prompt": TEST1_USER_PROMPT,
-        "round1": TEST1_ROUND1,
-        "perplexity": TEST1_PERPLEXITY,
+        "round1":      TEST1_ROUND1,
+        "perplexity":  TEST1_PERPLEXITY,
         "pass_criteria": [
             "Must present Claude Opus 4.7 at $5/$25",
             "Must mention Claude 3 Opus retirement (Jan 5, 2026)",
@@ -261,11 +368,11 @@ TESTS = [
         ],
     },
     {
-        "id": "test2-analytical",
+        "id":   "test2-analytical",
         "name": "Analytical Synthesis (the working case)",
         "user_prompt": TEST2_USER_PROMPT,
-        "round1": TEST2_ROUND1,
-        "perplexity": TEST2_PERPLEXITY,
+        "round1":      TEST2_ROUND1,
+        "perplexity":  TEST2_PERPLEXITY,
         "pass_criteria": [
             "Must mention DPO as the practical default",
             "Must attribute claims to specific round-1 models",
@@ -274,11 +381,11 @@ TESTS = [
         ],
     },
     {
-        "id": "test3-domain",
+        "id":   "test3-domain",
         "name": "Domain Technical (the showcase case)",
         "user_prompt": TEST3_USER_PROMPT,
-        "round1": TEST3_ROUND1,
-        "perplexity": TEST3_PERPLEXITY,
+        "round1":      TEST3_ROUND1,
+        "perplexity":  TEST3_PERPLEXITY,
         "pass_criteria": [
             "Must use RCA/RAA/QMRIC terminology (not MRI)",
             "Must note that Gemini's MRI terminology was incorrect",
@@ -288,18 +395,62 @@ TESTS = [
     },
 ]
 
-# ── Run evaluation ────────────────────────────────────────────────────────────
+# ── Monthly cost projection ───────────────────────────────────────────────────
+
+def project_monthly(avg_input_tokens: float, avg_output_tokens: float,
+                    input_rate: float, output_rate: float) -> dict:
+    """Project monthly synthesis cost at 100 / 1K / 10K sessions."""
+    per_session = calculate_cost(avg_input_tokens, avg_output_tokens,
+                                  input_rate, output_rate)
+    return {
+        "per_session": per_session,
+        "100_sessions":    round(per_session * 100,    4),
+        "1k_sessions":     round(per_session * 1_000,  3),
+        "10k_sessions":    round(per_session * 10_000, 2),
+    }
+
+# ── Tier-routing scenario ─────────────────────────────────────────────────────
+
+def compute_tier_routing(candidate_costs: dict) -> dict:
+    """
+    Blended cost for recommended tier-routing strategy:
+      60% Quick  → Haiku 4.5
+      30% Smart  → Sonnet 4.6
+      10% Deep   → Opus 4.7
+
+    candidate_costs: {candidate_key: {"per_session": float}}
+    Returns per-session blended cost and monthly projections.
+    """
+    haiku  = candidate_costs.get("Claude-Haiku-4-5",  {}).get("per_session", 0)
+    sonnet = candidate_costs.get("Claude-Sonnet-4-6", {}).get("per_session", 0)
+    opus   = candidate_costs.get("Claude-Opus-4-7",   {}).get("per_session", 0)
+
+    blended = 0.60 * haiku + 0.30 * sonnet + 0.10 * opus
+    return {
+        "haiku_weight":  0.60,
+        "sonnet_weight": 0.30,
+        "opus_weight":   0.10,
+        "haiku_per_session":  round(haiku,   6),
+        "sonnet_per_session": round(sonnet,  6),
+        "opus_per_session":   round(opus,    6),
+        "blended_per_session": round(blended, 6),
+        "blended_100":   round(blended * 100,    4),
+        "blended_1k":    round(blended * 1_000,  3),
+        "blended_10k":   round(blended * 10_000, 2),
+    }
+
+# ── Main evaluation ───────────────────────────────────────────────────────────
 
 def run_evaluation():
     results_dir = Path(__file__).parent / "results"
     results_dir.mkdir(exist_ok=True)
 
-    system = build_synthesis_system_prompt()
+    system    = build_synthesis_system_prompt()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    all_results = {}
+    all_results: dict = {}
 
     print(f"\n{'='*60}")
-    print("Synthesizer Evaluation Harness")
+    print("Synthesizer Evaluation Harness v2 — with cost analysis")
     print(f"Candidates: {len(AVAILABLE_CANDIDATES)}")
     print(f"Tests:      {len(TESTS)}")
     print(f"{'='*60}\n")
@@ -308,12 +459,20 @@ def run_evaluation():
         print("No candidates available. Check API keys in backend/.env.")
         return
 
-    for candidate_key in AVAILABLE_CANDIDATES:
-        print(f"\n── {candidate_key} ──")
-        safe_name = candidate_key.replace(" ", "-").replace("/", "-").replace("(", "").replace(")", "")
+    cost_data: dict = {}  # candidate_key → cost metadata
+
+    for candidate_key, cfg in AVAILABLE_CANDIDATES.items():
+        print(f"\n── {cfg['label']} ──")
+        safe_name     = candidate_key
         candidate_dir = results_dir / safe_name
         candidate_dir.mkdir(exist_ok=True)
+
         all_results[candidate_key] = {}
+        total_input_tokens  = 0
+        total_output_tokens = 0
+        total_cost          = 0.0
+        auto_passes         = 0
+        auto_total          = 0
 
         for test in TESTS:
             print(f"  Running {test['id']}...", end=" ", flush=True)
@@ -324,65 +483,193 @@ def run_evaluation():
             )
 
             try:
-                start = time.time()
-                output = call_candidate(candidate_key, user_message, system)
+                start  = time.time()
+                result = call_candidate(candidate_key, user_message, system)
                 elapsed = round(time.time() - start, 1)
-                status = "✓"
+                status  = "✓"
+                output         = result["text"]
+                input_tokens   = result["input_tokens"]
+                output_tokens  = result["output_tokens"]
             except Exception as e:
-                output = f"[ERROR: {e}]"
-                elapsed = 0.0
-                status = "✗"
+                output        = f"[ERROR: {e}]"
+                elapsed       = 0.0
+                status        = "✗"
+                input_tokens  = 0
+                output_tokens = 0
 
-            print(f"{status} ({elapsed}s)")
+            test_cost = calculate_cost(
+                input_tokens, output_tokens,
+                cfg["input_rate"], cfg["output_rate"]
+            )
+            total_input_tokens  += input_tokens
+            total_output_tokens += output_tokens
+            total_cost          += test_cost
 
+            # Automated criteria check
+            criteria_results = auto_check_criteria(output, test["pass_criteria"])
+            test_passes  = sum(1 for c in criteria_results if c["pass"] is True)
+            test_checks  = sum(1 for c in criteria_results if c["pass"] is not None)
+            auto_passes += test_passes
+            auto_total  += test_checks
+
+            print(f"{status} ({elapsed}s | {input_tokens}in+{output_tokens}out "
+                  f"tokens | ${test_cost:.5f})")
+
+            # Write per-test markdown
             result_path = candidate_dir / f"{test['id']}.md"
             with open(result_path, "w") as f:
-                f.write(f"# {candidate_key} — {test['name']}\n\n")
+                f.write(f"# {cfg['label']} — {test['name']}\n\n")
                 f.write(f"**Generated:** {timestamp}\n")
-                f.write(f"**Elapsed:** {elapsed}s\n\n")
+                f.write(f"**Elapsed:** {elapsed}s\n")
+                f.write(f"**Tokens:** {input_tokens} input / "
+                        f"{output_tokens} output\n")
+                f.write(f"**Cost:** ${test_cost:.6f}\n\n")
                 f.write("## Pass Criteria\n\n")
                 for criterion in test["pass_criteria"]:
                     f.write(f"- [ ] {criterion}\n")
+                f.write("\n## Automated Checks\n\n")
+                for c in criteria_results:
+                    icon = "✓" if c["pass"] else ("✗" if c["pass"] is False
+                                                  else "?")
+                    f.write(f"- {icon} {c['criterion']} "
+                            f"*({c['note']})*\n")
                 f.write("\n## Output\n\n")
                 f.write(output)
 
             all_results[candidate_key][test["id"]] = {
-                "output": output,
-                "elapsed": elapsed,
-                "status": status,
+                "output":        output,
+                "elapsed":       elapsed,
+                "status":        status,
+                "input_tokens":  input_tokens,
+                "output_tokens": output_tokens,
+                "cost":          round(test_cost, 6),
+                "criteria":      criteria_results,
             }
 
-            time.sleep(1)  # rate limit buffer
+            time.sleep(1)
 
-    # Write summary
+        # Per-candidate cost summary
+        avg_in  = total_input_tokens  / len(TESTS)
+        avg_out = total_output_tokens / len(TESTS)
+        monthly = project_monthly(avg_in, avg_out,
+                                   cfg["input_rate"], cfg["output_rate"])
+        auto_pct = (auto_passes / auto_total * 100) if auto_total else 0
+
+        cost_data[candidate_key] = {
+            "label":                cfg["label"],
+            "model":                cfg["model"],
+            "input_rate":           cfg["input_rate"],
+            "output_rate":          cfg["output_rate"],
+            "total_input_tokens":   total_input_tokens,
+            "total_output_tokens":  total_output_tokens,
+            "total_cost_3tests":    round(total_cost, 6),
+            "avg_input_tokens":     round(avg_in, 1),
+            "avg_output_tokens":    round(avg_out, 1),
+            "auto_pass_pct":        round(auto_pct, 1),
+            "monthly":              monthly,
+        }
+
+        print(f"  ── Totals: {total_input_tokens} in / {total_output_tokens} out "
+              f"tokens | ${total_cost:.5f} for 3 tests")
+        print(f"  ── Per session: ${monthly['per_session']:.6f} | "
+              f"1K sessions: ${monthly['1k_sessions']:.2f}")
+        print(f"  ── Auto criteria: {auto_passes}/{auto_total} "
+              f"({auto_pct:.0f}%)")
+
+    # ── Tier-routing scenario ─────────────────────────────────────────────────
+    monthly_by_candidate = {k: v["monthly"] for k, v in cost_data.items()}
+    tier_routing = compute_tier_routing(monthly_by_candidate)
+
+    # ── Save cost_data.json ───────────────────────────────────────────────────
+    cost_json_path = results_dir / f"cost_data-{timestamp}.json"
+    with open(cost_json_path, "w") as f:
+        json.dump({
+            "timestamp":    timestamp,
+            "candidates":   cost_data,
+            "tier_routing": tier_routing,
+        }, f, indent=2)
+
+    # ── Write summary markdown ────────────────────────────────────────────────
     summary_path = results_dir / f"summary-{timestamp}.md"
     with open(summary_path, "w") as f:
-        f.write("# Synthesizer Evaluation Summary\n\n")
+        f.write("# Synthesizer Evaluation Summary v2\n\n")
         f.write(f"**Date:** {timestamp}\n")
         f.write(f"**Candidates tested:** {len(AVAILABLE_CANDIDATES)}\n\n")
+
         f.write("## Results Matrix\n\n")
-        f.write("| Candidate | Test 1 Factual | Test 2 Analytical | Test 3 Domain |\n")
-        f.write("|-----------|---------------|------------------|---------------|\n")
-        for candidate_key in AVAILABLE_CANDIDATES:
-            row = f"| {candidate_key} |"
+        f.write("| Candidate | Test 1 | Test 2 | Test 3 | Auto% | "
+                "$/session | $/1K sessions |\n")
+        f.write("|-----------|--------|--------|--------|-------|"
+                "----------|---------------|\n")
+        for ck in AVAILABLE_CANDIDATES:
+            r    = all_results[ck]
+            cd   = cost_data[ck]
+            row  = f"| {cd['label']} |"
             for test in TESTS:
-                r = all_results[candidate_key][test["id"]]
-                row += f" {r['status']} ({r['elapsed']}s) |"
-            row += "\n"
-            f.write(row)
+                tr = r[test["id"]]
+                row += f" {tr['status']} ({tr['elapsed']}s) |"
+            row += (f" {cd['auto_pass_pct']}% |"
+                    f" ${cd['monthly']['per_session']:.5f} |"
+                    f" ${cd['monthly']['1k_sessions']:.2f} |")
+            f.write(row + "\n")
+
+        f.write("\n## Cost Analysis\n\n")
+        f.write("### Per-Candidate Token Counts (3-test total)\n\n")
+        f.write("| Candidate | Input tokens | Output tokens | 3-test cost |\n")
+        f.write("|-----------|-------------|--------------|-------------|\n")
+        for ck, cd in cost_data.items():
+            f.write(f"| {cd['label']} | {cd['total_input_tokens']:,} | "
+                    f"{cd['total_output_tokens']:,} | "
+                    f"${cd['total_cost_3tests']:.5f} |\n")
+
+        f.write("\n### Monthly Projections (synthesis calls only)\n\n")
+        f.write("| Candidate | 100 sessions | 1K sessions | 10K sessions |\n")
+        f.write("|-----------|-------------|------------|-------------|\n")
+        for ck, cd in cost_data.items():
+            m = cd["monthly"]
+            f.write(f"| {cd['label']} | ${m['100_sessions']:.3f} | "
+                    f"${m['1k_sessions']:.2f} | "
+                    f"${m['10k_sessions']:.2f} |\n")
+
+        f.write("\n### Tier-Routing Scenario (60% Quick / 30% Smart / 10% Deep)\n\n")
+        tr = tier_routing
+        f.write(f"Blended cost per session: **${tr['blended_per_session']:.6f}**\n\n")
+        f.write("| Volume | Uniform Opus | Uniform Haiku | Tier-Routed |\n")
+        f.write("|--------|-------------|--------------|-------------|\n")
+        opus_100  = cost_data.get("Claude-Opus-4-7",  {}).get("monthly", {}).get("100_sessions",  0)
+        haiku_100 = cost_data.get("Claude-Haiku-4-5", {}).get("monthly", {}).get("100_sessions",  0)
+        opus_1k   = cost_data.get("Claude-Opus-4-7",  {}).get("monthly", {}).get("1k_sessions",   0)
+        haiku_1k  = cost_data.get("Claude-Haiku-4-5", {}).get("monthly", {}).get("1k_sessions",   0)
+        opus_10k  = cost_data.get("Claude-Opus-4-7",  {}).get("monthly", {}).get("10k_sessions",  0)
+        haiku_10k = cost_data.get("Claude-Haiku-4-5", {}).get("monthly", {}).get("10k_sessions",  0)
+        f.write(f"| 100 sessions   | ${opus_100:.3f}  | ${haiku_100:.3f}   | "
+                f"${tr['blended_100']:.3f} |\n")
+        f.write(f"| 1K sessions    | ${opus_1k:.2f}   | ${haiku_1k:.2f}    | "
+                f"${tr['blended_1k']:.2f} |\n")
+        f.write(f"| 10K sessions   | ${opus_10k:.2f}  | ${haiku_10k:.2f}   | "
+                f"${tr['blended_10k']:.2f} |\n")
+
         f.write("\n## Scoring Rubric\n\n")
         f.write(SCORING_RUBRIC)
         f.write("\n\n## Next Steps\n\n")
         f.write("1. Read each candidate's output in `results/<candidate-name>/`\n")
-        f.write("2. Score each on the rubric above\n")
+        f.write("2. Score each on the 6-dimension rubric (1-5 per dim, max 30/test)\n")
         f.write("3. Pay special attention to Test 1 — the failing case\n")
-        f.write("4. Any candidate that calls Perplexity data 'fabricated' fails Test 1\n")
-        f.write("5. Document decision in `docs/decisions/002-synthesizer-selection.md`\n")
+        f.write("4. Record quality scores in `docs/decisions/002-synthesizer-"
+                "selection.md`\n")
+        f.write("5. Use quality-per-dollar (cost / score) to compare candidates\n")
+        f.write(f"\nCost data JSON: {cost_json_path}\n")
 
     print(f"\n{'='*60}")
     print("Evaluation complete.")
-    print(f"Results: {results_dir}")
-    print(f"Summary: {summary_path}")
+    print(f"Results:   {results_dir}")
+    print(f"Summary:   {summary_path}")
+    print(f"Cost JSON: {cost_json_path}")
+    if tier_routing.get("blended_per_session"):
+        print(f"\nTier-routing blended cost: "
+              f"${tier_routing['blended_per_session']:.6f}/session")
+        print(f"  1K sessions: ${tier_routing['blended_1k']:.2f}")
+        print(f"  10K sessions: ${tier_routing['blended_10k']:.2f}")
     print(f"{'='*60}\n")
 
 


### PR DESCRIPTION
## What
Combined evaluation harness covering synthesizer model selection,
intake model selection, and cost optimization analysis.

## Parts
- Part A: Synthesizer re-eval with 5 candidates (Opus 4.7, Sonnet 4.6,
  Haiku 4.5, GPT-4o, Qwen 2.5 72B) + token counting + cost metrics
- Part B: New intake eval with 6 tests including automated scoring
  and proper noun preservation as a pass/fail gate
- Part C: Combined cost report with tier-routing scenarios and
  prompt caching analysis
- Part D: ADR 002 updated, ADR 003 created

## Does not touch application code
No changes to backend/, frontend/, or tests/.

## How to run after merge
python -m experiments.synthesizer_eval.run_eval
python -m experiments.intake_eval.run_eval
python -m experiments.generate_cost_report