### PR TITLE
fix(intake): replace Gemini 2.5 Flash with GPT-4o Mini (100% eval score vs 29%)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,8 +9,9 @@ PERPLEXITY_API_KEY=
 GOOGLE_DRIVE_CLIENT_ID=
 GOOGLE_DRIVE_CLIENT_SECRET=
 
-# Intake model — Gemini 2.5 Flash stable (reuses GOOGLE_API_KEY, no new credentials needed)
-GEMINI_INTAKE_MODEL=gemini-2.5-flash
+# Intake model — GPT-4o Mini (100% assertion score in eval harness vs 29% for Gemini Flash)
+# Reuses OPENAI_API_KEY — no new credentials needed. Override to swap intake model.
+INTAKE_MODEL=gpt-4o-mini
 
 # OpenRouter — required for open-weight model evaluation (DeepSeek, Qwen, Llama)
 # Get key at: https://openrouter.ai/keys

--- a/backend/intake.py
+++ b/backend/intake.py
@@ -18,7 +18,7 @@ Functions:
 import re
 from typing import Any, Optional
 
-from backend.models.google_client import call_gemini_intake
+from backend.models.openai_client import call_gpt4o_mini_intake
 from backend.models.intake_decision import IntakeDecision
 
 # Unicode bidi overrides, directional formatting, and other invisible control characters.
@@ -112,7 +112,7 @@ class IntakeSession:
                 "config": dict,
             }
         """
-        decision = call_gemini_intake(prompt)
+        decision = call_gpt4o_mini_intake(prompt)
 
         if decision.needs_clarification:
             self._original_prompt = prompt
@@ -165,7 +165,7 @@ class IntakeSession:
             "Incorporate the user's clarification answer to add context and specificity, "
             "but keep the original proper nouns intact."
         )
-        decision = call_gemini_intake(combined)
+        decision = call_gpt4o_mini_intake(combined)
         self.complete = True
         self.session_config = _decision_to_config(decision)
         return {

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -5,6 +5,7 @@ GPT client for ai-roundtable v2 — OpenAI direct API.
 
 GPT's role in the roundtable:
     - Round 1: structure, actionability, breadth
+    - Intake: GPT-4o Mini analyzes prompts and returns structured IntakeDecision
 
 Tiers:
     quick   — gpt-4o
@@ -16,15 +17,20 @@ Functions:
         — primary call function used by Round 1
     call_gpt_smart(messages, system)
         — two-call executor + advisor pattern for Smart tier
+    call_gpt4o_mini_intake(prompt)
+        — intake analysis via GPT-4o Mini; returns IntakeDecision
     ping()
         — smoke test: confirm API key and connectivity
 """
 
 import asyncio
 import os
+import time
 from functools import partial
 
 from openai import OpenAI
+
+from backend.models.intake_decision import IntakeDecision
 
 _client = None
 
@@ -39,6 +45,137 @@ MODELS = {
     "smart": "gpt-4o",   # executor model for smart tier
     "deep":  "gpt-4o",
 }
+
+# Intake model — pinned separately from round-1 so it can be changed independently
+INTAKE_MODEL = os.getenv("INTAKE_MODEL", "gpt-4o-mini")
+
+# ── Intake system prompt ──────────────────────────────────────────────────────
+# Mirrors backend/models/google_client.py GEMINI_INTAKE_SYSTEM — kept here to
+# avoid importing from google_client when the Google SDK may not be installed.
+
+_INTAKE_SYSTEM = """
+You are an intake analyst for an AI research roundtable. Your job is to
+analyze a user's prompt and make two decisions:
+
+1. CLARIFICATION: Does the prompt have enough context to produce a
+   high-quality research session?
+
+   - If the user's intent is ambiguous or a critical piece of context is
+     missing, set needs_clarification to true and provide ONE focused
+     clarifying question. Do not ask multiple questions.
+   - If the prompt is clear enough to proceed, set needs_clarification
+     to false and optimize the prompt directly.
+
+2. PROPER NOUN PRESERVATION (critical rule):
+
+   When the user provides specific proper nouns — model names, product
+   names, version numbers, company names, or any named entity — treat
+   them as correct and authoritative. Never substitute your own examples
+   or alternatives.
+
+   WRONG: User says "Claude Opus 4.7" -> you ask "do you mean Claude 3 Opus?"
+   RIGHT: User says "Claude Opus 4.7" -> you use "Claude Opus 4.7" exactly
+
+   WRONG: User says "GPT-5" -> your clarifying question lists "GPT-4" as
+          an example of what they might mean
+   RIGHT: User says "GPT-5" -> you use "GPT-5" exactly in all outputs
+
+   If you are uncertain whether a named entity exists, do NOT ask the user
+   to confirm using your own alternatives. Instead, ask about their INTENT
+   or SCOPE only — never suggest replacement names.
+
+3. TIER ASSIGNMENT: What research depth does this prompt require?
+
+   - quick : factual lookups, simple comparisons, gut checks.
+             Single-dimension questions with known answers.
+   - smart : analysis, recommendations, technical evaluations.
+             Requires weighing tradeoffs or synthesizing multiple sources.
+   - deep  : architecture decisions, strategic plans, critical reports.
+             High stakes, significant ambiguity, or complex dependencies.
+
+   Assign tier based on complexity and stakes — not prompt length.
+   A short prompt can require deep research.
+
+Always return valid JSON matching the schema exactly. No prose outside the
+JSON object. Required fields:
+  needs_clarification (bool), clarifying_question (string or null),
+  optimized_prompt (string), tier ("quick"|"smart"|"deep"),
+  output_type (string), reasoning (string)
+"""
+
+
+def _is_retriable(exc: Exception) -> bool:
+    """Return True if the exception warrants a retry (rate limit or transient error)."""
+    msg = str(exc).lower()
+    return ("429" in msg or "503" in msg or "rate" in msg
+            or "unavailable" in msg or "rate_limit" in msg)
+
+
+def _call_gpt4o_mini_intake_once(prompt: str) -> IntakeDecision:
+    """Single attempt against INTAKE_MODEL — no retry logic."""
+    response = _get_client().chat.completions.create(
+        model=INTAKE_MODEL,
+        max_tokens=512,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": _INTAKE_SYSTEM},
+            {"role": "user",   "content": prompt},
+        ],
+    )
+    raw = response.choices[0].message.content or ""
+    try:
+        return IntakeDecision.model_validate_json(raw)
+    except Exception as e:
+        raise ValueError(
+            f"GPT-4o Mini intake schema validation failed: {e}. "
+            f"Raw response: {raw!r}"
+        )
+
+
+def call_gpt4o_mini_intake(prompt: str) -> IntakeDecision:
+    """
+    Analyze a user's intake prompt with GPT-4o Mini and return a structured decision.
+
+    Uses json_object response_format to enforce JSON output. Validates the
+    parsed JSON against the IntakeDecision schema.
+
+    Retry policy:
+      - Rate limit (429) and transient (503) errors: 3 attempts with
+        exponential backoff (2 s -> 4 s -> raises).
+      - All other errors raise immediately — no retry.
+
+    Args:
+        prompt: The user's raw prompt, or a combined clarification turn string.
+
+    Returns:
+        IntakeDecision with tier, optimized_prompt, and optional clarifying_question.
+
+    Raises:
+        ValueError:   if the API response fails schema validation (no retry).
+        RuntimeError: if GPT-4o Mini is unavailable on all 3 attempts.
+        Exception:    on any other API error (raised immediately).
+    """
+    last_exc = None
+    delays = [2, 4]  # seconds between attempts 1->2 and 2->3
+
+    for attempt in range(3):
+        try:
+            return _call_gpt4o_mini_intake_once(prompt)
+        except Exception as exc:
+            if _is_retriable(exc):
+                last_exc = exc
+                if attempt < len(delays):
+                    time.sleep(delays[attempt])
+                continue
+            raise  # non-retriable errors raise immediately
+
+    raise RuntimeError(
+        "GPT-4o Mini intake unavailable after 3 attempts — please try again in a moment."
+    ) from last_exc
+
+
+# ── Round 1 call functions ────────────────────────────────────────────────────
 
 # gpt-5 as advisor; fall back to gpt-4o if not yet available on this account
 _ADVISOR_MODEL = "gpt-4o"

--- a/tests/test_gemini_intake.py
+++ b/tests/test_gemini_intake.py
@@ -1,7 +1,7 @@
 """
 tests/test_gemini_intake.py
 
-Tests for Gemini Flash-powered intake. call_gemini_intake() is mocked —
+Tests for intake session logic. call_gpt4o_mini_intake() is mocked —
 no real API calls are made.
 
 Run with:
@@ -57,7 +57,7 @@ FINAL_DECISION = _decision(
 # ---------------------------------------------------------------------------
 
 def test_clear_prompt_completes_in_one_turn():
-    with patch("backend.intake.call_gemini_intake", return_value=CLEAR_DECISION):
+    with patch("backend.intake.call_gpt4o_mini_intake", return_value=CLEAR_DECISION):
         session = IntakeSession()
         result = session.analyze("How do I design a RAG pipeline?")
 
@@ -74,7 +74,7 @@ def test_clear_prompt_completes_in_one_turn():
 # ---------------------------------------------------------------------------
 
 def test_ambiguous_prompt_returns_clarifying_question():
-    with patch("backend.intake.call_gemini_intake", return_value=AMBIGUOUS_DECISION):
+    with patch("backend.intake.call_gpt4o_mini_intake", return_value=AMBIGUOUS_DECISION):
         session = IntakeSession()
         result = session.analyze("I need help with my project")
 
@@ -90,7 +90,7 @@ def test_ambiguous_prompt_returns_clarifying_question():
 # ---------------------------------------------------------------------------
 
 def test_clarification_answer_completes_session():
-    with patch("backend.intake.call_gemini_intake", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]):
+    with patch("backend.intake.call_gpt4o_mini_intake", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]):
         session = IntakeSession()
         r1 = session.analyze("I need help with my project")
         assert r1["status"] == "clarifying"
@@ -110,7 +110,7 @@ def test_clarification_answer_completes_session():
 @pytest.mark.parametrize("tier", ["quick", "smart", "deep"])
 def test_tier_is_valid_literal(tier):
     decision = _decision(tier=tier)
-    with patch("backend.intake.call_gemini_intake", return_value=decision):
+    with patch("backend.intake.call_gpt4o_mini_intake", return_value=decision):
         session = IntakeSession()
         result = session.analyze("Test prompt")
     assert result["config"]["tier"] == tier
@@ -132,7 +132,7 @@ def test_invalid_tier_raises_validation_error():
 # ---------------------------------------------------------------------------
 
 def test_second_respond_returns_existing_config_without_api_call():
-    with patch("backend.intake.call_gemini_intake", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]) as mock_api:
+    with patch("backend.intake.call_gpt4o_mini_intake", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]) as mock_api:
         session = IntakeSession()
         session.analyze("Ambiguous prompt")
         session.respond("First answer")
@@ -193,18 +193,18 @@ def test_unknown_session_returns_404():
 
 
 # ---------------------------------------------------------------------------
-# Test 8: Retry logic — 503 handling in call_gemini_intake()
+# Test 8: Retry logic — rate limit / transient error handling in call_gpt4o_mini_intake()
 # ---------------------------------------------------------------------------
 
 def test_503_on_first_attempt_succeeds_on_second():
     """503 on attempt 1, success on attempt 2 → returns IntakeDecision."""
-    from backend.models.google_client import call_gemini_intake
+    from backend.models.openai_client import call_gpt4o_mini_intake
 
     error_503 = Exception("503 Service Unavailable")
-    with patch("backend.models.google_client._call_gemini_intake_once",
+    with patch("backend.models.openai_client._call_gpt4o_mini_intake_once",
                side_effect=[error_503, CLEAR_DECISION]) as mock_call, \
-         patch("backend.models.google_client.time.sleep") as mock_sleep:
-        result = call_gemini_intake("test prompt")
+         patch("backend.models.openai_client.time.sleep") as mock_sleep:
+        result = call_gpt4o_mini_intake("test prompt")
 
     assert result == CLEAR_DECISION
     assert mock_call.call_count == 2
@@ -213,29 +213,29 @@ def test_503_on_first_attempt_succeeds_on_second():
 
 def test_503_all_three_attempts_raises_runtime_error():
     """503 on all 3 attempts → RuntimeError with the exact user-facing message."""
-    from backend.models.google_client import call_gemini_intake
+    from backend.models.openai_client import call_gpt4o_mini_intake
 
     error_503 = Exception("503 Service Unavailable")
-    with patch("backend.models.google_client._call_gemini_intake_once",
+    with patch("backend.models.openai_client._call_gpt4o_mini_intake_once",
                side_effect=[error_503, error_503, error_503]), \
-         patch("backend.models.google_client.time.sleep"):
+         patch("backend.models.openai_client.time.sleep"):
         with pytest.raises(RuntimeError) as exc_info:
-            call_gemini_intake("test prompt")
+            call_gpt4o_mini_intake("test prompt")
 
     assert "unavailable after 3 attempts" in str(exc_info.value)
     assert "please try again in a moment" in str(exc_info.value)
 
 
 def test_non_503_raises_immediately_without_retry():
-    """404 (or any non-503) on the first attempt → raises immediately, no sleep."""
-    from backend.models.google_client import call_gemini_intake
+    """404 (or any non-retriable error) on the first attempt → raises immediately, no sleep."""
+    from backend.models.openai_client import call_gpt4o_mini_intake
 
     error_404 = Exception("404 model not found")
-    with patch("backend.models.google_client._call_gemini_intake_once",
+    with patch("backend.models.openai_client._call_gpt4o_mini_intake_once",
                side_effect=error_404) as mock_call, \
-         patch("backend.models.google_client.time.sleep") as mock_sleep:
+         patch("backend.models.openai_client.time.sleep") as mock_sleep:
         with pytest.raises(Exception, match="404"):
-            call_gemini_intake("test prompt")
+            call_gpt4o_mini_intake("test prompt")
 
     assert mock_call.call_count == 1   # single attempt only
     mock_sleep.assert_not_called()
@@ -243,14 +243,14 @@ def test_non_503_raises_immediately_without_retry():
 
 def test_retry_sleep_called_with_correct_delays():
     """Exponential backoff: sleep(2) after attempt 1, sleep(4) after attempt 2, no sleep after 3."""
-    from backend.models.google_client import call_gemini_intake
+    from backend.models.openai_client import call_gpt4o_mini_intake
 
     error_503 = Exception("unavailable")
-    with patch("backend.models.google_client._call_gemini_intake_once",
+    with patch("backend.models.openai_client._call_gpt4o_mini_intake_once",
                side_effect=[error_503, error_503, error_503]), \
-         patch("backend.models.google_client.time.sleep") as mock_sleep:
+         patch("backend.models.openai_client.time.sleep") as mock_sleep:
         with pytest.raises(RuntimeError):
-            call_gemini_intake("test prompt")
+            call_gpt4o_mini_intake("test prompt")
 
     assert mock_sleep.call_count == 2
     mock_sleep.assert_any_call(2)
@@ -290,7 +290,7 @@ def test_clarifying_question_does_not_substitute_model_names():
     This test asserts the correct pattern: an intent-only question contains
     no model names from the training data that contradict the user's prompt.
     """
-    with patch("backend.intake.call_gemini_intake", return_value=_INTENT_ONLY_QUESTION):
+    with patch("backend.intake.call_gpt4o_mini_intake", return_value=_INTENT_ONLY_QUESTION):
         session = IntakeSession()
         result = session.analyze(_PRICING_PROMPT)
 
@@ -307,7 +307,7 @@ def test_clarifying_question_with_substituted_names_is_detectable():
     the assertions above would catch it. This test confirms the detection logic
     works against a known-bad response.
     """
-    with patch("backend.intake.call_gemini_intake", return_value=_SUBSTITUTED_QUESTION):
+    with patch("backend.intake.call_gpt4o_mini_intake", return_value=_SUBSTITUTED_QUESTION):
         session = IntakeSession()
         result = session.analyze(_PRICING_PROMPT)
 
@@ -351,7 +351,7 @@ def test_turn1_optimized_prompt_preserves_original_model_names():
     After the user answers the clarifying question, the optimized_prompt must
     contain the model names from the original prompt, not substitutions.
     """
-    with patch("backend.intake.call_gemini_intake",
+    with patch("backend.intake.call_gpt4o_mini_intake",
                side_effect=[_INTENT_ONLY_QUESTION, _PRESERVED_FINAL]):
         session = IntakeSession()
         session.analyze(_PRICING_PROMPT)
@@ -372,7 +372,7 @@ def test_turn1_substituted_prompt_is_detectable():
     substituted model names, the assertions above would catch it. This test
     confirms the detection logic works against a known-bad response.
     """
-    with patch("backend.intake.call_gemini_intake",
+    with patch("backend.intake.call_gpt4o_mini_intake",
                side_effect=[_INTENT_ONLY_QUESTION, _SUBSTITUTED_FINAL]):
         session = IntakeSession()
         session.analyze(_PRICING_PROMPT)


### PR DESCRIPTION
## What
Replaces Gemini 2.5 Flash as the intake model with GPT-4o Mini.

## Why
Intake eval results (experiments/intake_eval/):
- GPT-4o Mini: 16/16 assertions (100%), $0.23/1K sessions
- Gemini 2.5 Flash: 4/14 assertions (29%), failing proper noun preservation

Gemini 2.5 Flash was substituting 2024 model names for the models users
explicitly provided — a user-facing bug that persisted despite system
prompt fixes.

## Changes
- call_gpt4o_mini_intake() added to openai_client.py
  (response_format json_object, temperature 0.1, 3-attempt retry)
- backend/intake.py import swapped to GPT-4o Mini
- .env.example updated
- All 10 mock patches updated in test_gemini_intake.py

## Validation
Run pricing prompt after merge — intake must preserve
"Claude Opus 4.7", "GPT-5", "Gemini 2.5 Pro" exactly.