### PR TITLE
feat(resilience): intake fallback chain, synthesis router, research resilience, factcheck Smart/Deep

### DIFF
--- a/backend/intake.py
+++ b/backend/intake.py
@@ -15,11 +15,14 @@ Functions:
     sanitize_config — recursively sanitize string values in a config dict
 """
 
+import logging
 import re
 from typing import Any, Optional
 
-from backend.models.openai_client import call_gpt4o_mini_intake
 from backend.models.intake_decision import IntakeDecision
+from backend.models.resilient_caller import call_with_fallback
+
+logger = logging.getLogger(__name__)
 
 # Unicode bidi overrides, directional formatting, and other invisible control characters.
 # Ranges covered:
@@ -52,6 +55,51 @@ def sanitize_config(obj: Any) -> Any:
     if isinstance(obj, list):
         return [sanitize_config(item) for item in obj]
     return obj
+
+
+def _intake_passthrough(prompt: str) -> IntakeDecision:
+    """
+    Emergency passthrough — all intake models failed.
+    Returns raw prompt with smart tier defaults.
+    Never raises. Logs warning for monitoring.
+    """
+    logger.warning(
+        "Intake passthrough triggered — all models unavailable. "
+        "Session will run with unoptimized prompt at smart tier."
+    )
+    return IntakeDecision(
+        needs_clarification=False,
+        clarifying_question=None,
+        optimized_prompt=prompt,
+        tier="smart",
+        output_type="analysis",
+        reasoning="Intake service temporarily unavailable — running with smart tier default.",
+    )
+
+
+def call_intake(prompt: str) -> tuple:
+    """
+    Run intake with fallback chain. Returns (IntakeDecision, provider_used).
+
+    Chain:
+        Primary:   INTAKE_PRIMARY   (gpt-4o-mini, OpenAI)
+        Fallback1: INTAKE_FALLBACK1 (qwen-2.5-72b, OpenRouter)
+        Fallback2: INTAKE_FALLBACK2 (claude-haiku, Anthropic)
+        Emergency: Passthrough      (smart tier defaults, never fails)
+    """
+    from backend.models.openai_client import call_intake_primary
+    from backend.models.openrouter_client import call_intake_fallback1
+    from backend.models.anthropic_client import call_intake_fallback2
+
+    return call_with_fallback(
+        primary_fn=lambda: call_intake_primary(prompt),
+        fallback_fns=[
+            lambda: call_intake_fallback1(prompt),
+            lambda: call_intake_fallback2(prompt),
+        ],
+        emergency_fn=lambda: _intake_passthrough(prompt),
+        role="intake",
+    )
 
 
 def _decision_to_config(decision: IntakeDecision) -> dict:
@@ -94,6 +142,7 @@ class IntakeSession:
         self.session_config: Optional[dict] = None
         self._original_prompt: Optional[str] = None
         self._clarifying_question: Optional[str] = None
+        self._intake_provider: str = "unknown"
 
     def analyze(self, prompt: str) -> dict:
         """
@@ -112,7 +161,8 @@ class IntakeSession:
                 "config": dict,
             }
         """
-        decision = call_gpt4o_mini_intake(prompt)
+        decision, provider_used = call_intake(prompt)
+        self._intake_provider = provider_used
 
         if decision.needs_clarification:
             self._original_prompt = prompt
@@ -165,7 +215,8 @@ class IntakeSession:
             "Incorporate the user's clarification answer to add context and specificity, "
             "but keep the original proper nouns intact."
         )
-        decision = call_gpt4o_mini_intake(combined)
+        decision, provider_used = call_intake(combined)
+        self._intake_provider = provider_used
         self.complete = True
         self.session_config = _decision_to_config(decision)
         return {

--- a/backend/main.py
+++ b/backend/main.py
@@ -59,6 +59,7 @@ from backend.router import (
     get_tier_config,
     get_round1_system_prompt,
     build_synthesis_prompt,
+    select_synthesis_model,
     USE_CASE_LIBRARY,
     get_use_case,
 )
@@ -66,18 +67,26 @@ from backend.models.anthropic_client import (
     call_claude,
     call_claude_smart,
     call_claude_smart_async,
+    call_research_claude_async,
 )
 from backend.models.google_client import (
     call_gemini,
     call_gemini_smart,
     call_gemini_smart_async,
+    call_research_gemini_async,
 )
-from backend.models.openai_client import call_gpt, call_gpt_smart, call_gpt_smart_async
-from backend.models.grok_client import call_grok, call_grok_smart, call_grok_smart_async
+from backend.models.openai_client import (
+    call_gpt, call_gpt_smart, call_gpt_smart_async, call_research_gpt_async,
+)
+from backend.models.grok_client import (
+    call_grok, call_grok_smart, call_grok_smart_async, call_research_grok_async,
+)
 from backend.models.perplexity_client import (
     research as perplexity_research,
-    audit as perplexity_audit,
+    audit_with_fallback,
 )
+from backend.models.pipeline_health import PipelineHealth
+from backend.models.model_config import SYNTHESIS_FALLBACK
 from backend.exporter import Exporter
 from backend.models.model_validator import validate_model_config
 
@@ -264,13 +273,11 @@ async def session_run(req: SessionRunRequest):
     tier = config.get("tier", "smart"); print(f"[SESSION] tier={tier}", flush=True)
     output_type = config.get("output_type", "report")
     optimized_prompt = config.get("optimized_prompt", req.prompt)
+    health = PipelineHealth()
 
-    try:
-        tier_config = get_tier_config(tier)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    mode = tier_config.get("mode", "single")
+    # Tier must be "smart" or "deep" — anything else defaults to smart
+    if tier not in ("smart", "deep"):
+        tier = "smart"
 
     transcript = Transcript()
     transcript.session_config = config
@@ -285,9 +292,6 @@ async def session_run(req: SessionRunRequest):
             )
     transcript.add_user_message(req.prompt)
 
-    def _skip(sender: str, exc: Exception) -> str:
-        return f"[{sender} unavailable — skipped after retries: {exc}]"
-
     gemini_history = transcript.get_history_for_model("gemini")
     gpt_history    = transcript.get_history_for_model("gpt")
     grok_history   = transcript.get_history_for_model("grok")
@@ -298,91 +302,6 @@ async def session_run(req: SessionRunRequest):
     claude_system  = get_round1_system_prompt("claude")
 
     # ── Parallel: Gemini + GPT + Grok + Claude + Perplexity pre-research ─────
-    if mode == "smart":
-        async def _gemini_task() -> str:
-            try:
-                result = await _call_with_retry_async(
-                    lambda: call_gemini_smart_async(gemini_history, gemini_system),
-                    "Gemini-smart",
-                )
-                return result["advisor_text"]
-            except Exception as exc:
-                return _skip("Gemini", exc)
-
-        async def _gpt_task() -> str:
-            try:
-                result = await _call_with_retry_async(
-                    lambda: call_gpt_smart_async(gpt_history, gpt_system),
-                    "GPT-smart",
-                )
-                return result["advisor_text"]
-            except Exception as exc:
-                return _skip("GPT", exc)
-
-        async def _grok_task() -> str:
-            try:
-                result = await _call_with_retry_async(
-                    lambda: call_grok_smart_async(grok_history, grok_system),
-                    "Grok-smart",
-                )
-                return result["advisor_text"]
-            except Exception as exc:
-                return _skip("Grok", exc)
-
-        async def _claude_r1_task() -> str:
-            try:
-                result = await _call_with_retry_async(
-                    lambda: call_claude_smart_async(claude_history, claude_system),
-                    "Claude-round1-smart",
-                )
-                return result["advisor_text"]
-            except Exception as exc:
-                return _skip("Claude", exc)
-    else:
-        async def _gemini_task() -> str:
-            try:
-                r = await asyncio.to_thread(
-                    _call_with_retry,
-                    lambda: call_gemini(messages=gemini_history, tier=tier, system=gemini_system),
-                    "Gemini",
-                )
-                return r.text
-            except Exception as exc:
-                return _skip("Gemini", exc)
-
-        async def _gpt_task() -> str:
-            try:
-                r = await asyncio.to_thread(
-                    _call_with_retry,
-                    lambda: call_gpt(messages=gpt_history, tier=tier, system=gpt_system),
-                    "GPT",
-                )
-                return r.choices[0].message.content
-            except Exception as exc:
-                return _skip("GPT", exc)
-
-        async def _grok_task() -> str:
-            try:
-                r = await asyncio.to_thread(
-                    _call_with_retry,
-                    lambda: call_grok(messages=grok_history, tier=tier, system=grok_system),
-                    "Grok",
-                )
-                return r.choices[0].message.content
-            except Exception as exc:
-                return _skip("Grok", exc)
-
-        async def _claude_r1_task() -> str:
-            try:
-                r = await asyncio.to_thread(
-                    _call_with_retry,
-                    lambda: call_claude(messages=claude_history, tier=tier, system=claude_system),
-                    "Claude-round1",
-                )
-                return r.content[0].text
-            except Exception as exc:
-                return _skip("Claude", exc)
-
     async def _research_task() -> str:
         try:
             return await asyncio.to_thread(
@@ -393,31 +312,58 @@ async def session_run(req: SessionRunRequest):
         except Exception as exc:
             return f"[Perplexity pre-research unavailable: {exc}]"
 
-    gemini_text, gpt_text, grok_text, claude_r1_text, perplexity_pre = await asyncio.gather(
-        _gemini_task(), _gpt_task(), _grok_task(), _claude_r1_task(), _research_task(),
+    results = await asyncio.gather(
+        call_research_gemini_async(gemini_history, gemini_system, tier),
+        call_research_gpt_async(gpt_history, gpt_system, tier),
+        call_research_grok_async(grok_history, grok_system, tier),
+        call_research_claude_async(claude_history, claude_system, tier),
+        _research_task(),
+        return_exceptions=True,
     )
+
+    def _unpack(result, lab: str) -> tuple:
+        if isinstance(result, Exception):
+            return f"[{lab.capitalize()} unavailable — {result}]", "unavailable"
+        if isinstance(result, tuple):
+            return result
+        return str(result), "primary"
+
+    gemini_text,    gemini_avail    = _unpack(results[0], "gemini")
+    gpt_text,       gpt_avail       = _unpack(results[1], "gpt")
+    grok_text,      grok_avail      = _unpack(results[2], "grok")
+    claude_r1_text, claude_avail    = _unpack(results[3], "claude")
+    perplexity_pre = results[4] if isinstance(results[4], str) else ""
+
+    health.research_models = {
+        "gemini": gemini_avail,
+        "gpt":    gpt_avail,
+        "grok":   grok_avail,
+        "claude": claude_avail,
+    }
 
     transcript.add_model_message("Gemini", gemini_text,    round="round1")
     transcript.add_model_message("GPT",    gpt_text,       round="round1")
     transcript.add_model_message("Grok",   grok_text,      round="round1")
     transcript.add_model_message("Claude", claude_r1_text, round="round1")
 
-    # ── Perplexity audit (Phase 2) ────────────────────────────────────────────
+    # ── Perplexity audit (Phase 2) with fallback ──────────────────────────────
     try:
-        audit_text = await asyncio.to_thread(
-            _call_with_retry,
-            lambda: perplexity_audit(
-                {"gemini": gemini_text, "gpt": gpt_text, "grok": grok_text},
-                research_text=perplexity_pre,
-                tier=tier,
-            ),
-            "Perplexity-audit",
+        audit_text, factcheck_provider = await asyncio.to_thread(
+            audit_with_fallback,
+            {"gemini": gemini_text, "gpt": gpt_text,
+             "grok": grok_text, "claude": claude_r1_text},
+            perplexity_pre,
+            tier,
         )
     except Exception as exc:
         audit_text = f"[Perplexity audit unavailable: {exc}]"
+        factcheck_provider = "emergency"
+    health.factcheck_model = factcheck_provider
+    health.factcheck_degraded = (factcheck_provider != "primary")
     transcript.add_model_message("Perplexity", audit_text, round="audit")
 
-    # ── Synthesis: Claude (smart: executor → advisor; else: single call) ──────
+    # ── Synthesis: route to analytical or factual model based on audit ────────
+    synthesis_model_id, synthesis_route = select_synthesis_model(audit_text)
     synthesis_system = build_synthesis_prompt(
         output_type=output_type,
         perplexity_findings=audit_text,
@@ -429,23 +375,28 @@ async def session_run(req: SessionRunRequest):
         },
         optimized_prompt=optimized_prompt,
     )
-    if mode == "smart":
-        result = await _call_with_retry_async(
-            lambda: call_claude_smart_async(
-                [{"role": "user", "content": req.prompt}],
-                synthesis_system,
-            ),
-            "Claude-smart",
+    synthesis_messages = [{"role": "user", "content": req.prompt}]
+    try:
+        synthesis_text = await call_synthesis_async(
+            synthesis_model_id, synthesis_messages, synthesis_system, tier
         )
-        synthesis_text = result["advisor_text"]
-    else:
-        synthesis_response = call_claude(
-            messages=[{"role": "user", "content": req.prompt}],
-            tier=tier,
-            system=synthesis_system,
-        )
-        synthesis_text = synthesis_response.content[0].text
+        health.synthesis_model = synthesis_model_id
+        health.synthesis_routed = synthesis_route
+    except Exception as exc:
+        print(f"[synthesis] primary failed ({exc}) — using fallback", flush=True)
+        try:
+            synthesis_text = await call_synthesis_async(
+                SYNTHESIS_FALLBACK, synthesis_messages, synthesis_system, tier
+            )
+            health.synthesis_model = SYNTHESIS_FALLBACK
+            health.synthesis_routed = f"{synthesis_route}_fallback"
+        except Exception as exc2:
+            synthesis_text = f"[Synthesis unavailable: {exc2}]"
+            health.synthesis_model = "emergency"
+            health.synthesis_routed = f"{synthesis_route}_fallback"
+
     transcript.add_model_message("Claude", synthesis_text, round="synthesis")
+    print(f"[SESSION] {health.summary()}", flush=True)
 
     return {
         "round1": {
@@ -454,8 +405,10 @@ async def session_run(req: SessionRunRequest):
             "grok":   grok_text,
             "claude": claude_r1_text,
         },
-        "audit":     audit_text,
-        "synthesis": synthesis_text,
+        "audit":             audit_text,
+        "synthesis":         synthesis_text,
+        "pipeline_health":   health.summary(),
+        "annotations":       health.to_annotation(),
     }
 
 
@@ -710,6 +663,42 @@ def _call_with_retry(fn, sender: str):
     raise last_exc
 
 
+async def call_synthesis_async(
+    model: str,
+    messages: list,
+    system: str,
+    tier: str,
+) -> str:
+    """
+    Dispatch synthesis to the correct provider based on model ID prefix.
+
+    claude/* → Anthropic (smart: executor+advisor; deep: single opus call)
+    gpt/*    → OpenAI
+    qwen/*   → OpenRouter
+    """
+    if model.startswith("claude"):
+        if tier == "smart":
+            result = await _call_with_retry_async(
+                lambda: call_claude_smart_async(messages, system),
+                "Claude-synthesis-smart",
+            )
+            return result["advisor_text"]
+        else:
+            result = await asyncio.to_thread(
+                call_claude, messages=messages, tier="deep", system=system
+            )
+            return result.content[0].text
+    elif model.startswith("gpt"):
+        result = await asyncio.to_thread(
+            call_gpt, messages=messages, tier="deep", system=system
+        )
+        return result.choices[0].message.content
+    else:
+        # OpenRouter fallback (Qwen or other)
+        from backend.models.openrouter_client import call_synthesis_fallback
+        return await asyncio.to_thread(call_synthesis_fallback, messages, system)
+
+
 async def _call_with_retry_async(coro_factory, sender: str):
     """
     Await coro_factory() with up to 3 retries on retryable errors (503 / 429 / rate-limit).
@@ -915,7 +904,10 @@ async def session_websocket(websocket: WebSocket):
         await websocket.close()
         return
 
-    mode = tier_config.get("mode", "single")
+    # Tier must be "smart" or "deep" — anything else defaults to smart
+    if tier not in ("smart", "deep"):
+        tier = "smart"
+    health = PipelineHealth()
     optimized_prompt = config.get("optimized_prompt", prompt)
     transcript = _build_transcript(config, history, prompt)
 
@@ -923,10 +915,7 @@ async def session_websocket(websocket: WebSocket):
     try:
         await websocket.send_json({"type": "session_started"})
 
-        # ── Round 1 + Perplexity pre-research ───────────────────────────────────
-        # quick/deep: stream all four models in parallel.
-        # smart: async smart clients (executor + advisor) off the event loop,
-        # then chunk-emit advisor text for all four models simultaneously.
+        # ── Round 1: all four labs + Perplexity pre-research ─────────────────
         gemini_history = transcript.get_history_for_model("gemini")
         gpt_history    = transcript.get_history_for_model("gpt")
         grok_history   = transcript.get_history_for_model("grok")
@@ -947,144 +936,77 @@ async def session_websocket(websocket: WebSocket):
             except Exception as exc:
                 return f"[Perplexity pre-research unavailable: {exc}]"
 
-        def _smart_round1_body(res, sender_name: str) -> str:
-            if isinstance(res, Exception):
-                return f"[{sender_name} unavailable — skipped after retries: {res}]"
-            if isinstance(res, dict) and res.get("advisor_text") is not None:
-                return str(res["advisor_text"])
-            return f"[{sender_name} unavailable]"
+        results = await asyncio.gather(
+            call_research_gemini_async(gemini_history, gemini_system, tier),
+            call_research_gpt_async(gpt_history, gpt_system, tier),
+            call_research_grok_async(grok_history, grok_system, tier),
+            call_research_claude_async(claude_history, claude_system, tier),
+            _research_task(),
+            return_exceptions=True,
+        )
 
-        if mode == "smart":
-            r1_results = await asyncio.gather(
-                _research_task(),
-                _call_with_retry_async(
-                    lambda: call_gemini_smart_async(gemini_history, gemini_system),
-                    "Gemini-smart",
-                ),
-                _call_with_retry_async(
-                    lambda: call_gpt_smart_async(gpt_history, gpt_system),
-                    "GPT-smart",
-                ),
-                _call_with_retry_async(
-                    lambda: call_grok_smart_async(grok_history, grok_system),
-                    "Grok-smart",
-                ),
-                _call_with_retry_async(
-                    lambda: call_claude_smart_async(claude_history, claude_system),
-                    "Claude-round1",
-                ),
-                return_exceptions=True,
-            )
-            perplexity_pre    = r1_results[0] if isinstance(r1_results[0], str) else ""
-            gem_res           = r1_results[1]
-            gpt_res           = r1_results[2]
-            grok_res          = r1_results[3]
-            claude_r1_res     = r1_results[4]
-            gemini_text_body      = _smart_round1_body(gem_res,       "Gemini")
-            gpt_text_body         = _smart_round1_body(gpt_res,       "GPT")
-            grok_text_body        = _smart_round1_body(grok_res,      "Grok")
-            claude_r1_text_body   = _smart_round1_body(claude_r1_res, "Claude")
+        def _unpack(result, lab: str) -> tuple:
+            if isinstance(result, Exception):
+                return f"[{lab.capitalize()} unavailable — {result}]", "unavailable"
+            if isinstance(result, tuple):
+                return result
+            return str(result), "primary"
 
-            async def _emit_model_tokens(sender: str, text: str) -> None:
-                body = text or ""
-                step = 48
-                for i in range(0, len(body), step):
-                    piece = body[i : i + step]
-                    async with send_lock:
-                        await websocket.send_json({"type": "token", "sender": sender, "token": piece})
+        gemini_text,    gemini_avail    = _unpack(results[0], "gemini")
+        gpt_text,       gpt_avail       = _unpack(results[1], "gpt")
+        grok_text,      grok_avail      = _unpack(results[2], "grok")
+        claude_r1_text, claude_avail    = _unpack(results[3], "claude")
+        perplexity_pre = results[4] if isinstance(results[4], str) else ""
+
+        health.research_models = {
+            "gemini": gemini_avail,
+            "gpt":    gpt_avail,
+            "grok":   grok_avail,
+            "claude": claude_avail,
+        }
+
+        async def _emit_model_tokens(sender: str, text: str) -> None:
+            body = text or ""
+            step = 48
+            for i in range(0, len(body), step):
+                piece = body[i : i + step]
                 async with send_lock:
-                    await websocket.send_json({"type": "model_complete", "sender": sender})
+                    await websocket.send_json({"type": "token", "sender": sender, "token": piece})
+            async with send_lock:
+                await websocket.send_json({"type": "model_complete", "sender": sender})
 
-            await asyncio.gather(
-                _emit_model_tokens("Gemini", gemini_text_body),
-                _emit_model_tokens("GPT",    gpt_text_body),
-                _emit_model_tokens("Grok",   grok_text_body),
-                _emit_model_tokens("Claude", claude_r1_text_body),
-            )
-            gemini_text    = gemini_text_body
-            gpt_text       = gpt_text_body
-            grok_text      = grok_text_body
-            claude_r1_text = claude_r1_text_body
-        else:
-            results = await asyncio.gather(
-                _stream_model(
-                    websocket, "Gemini",
-                    lambda: _gemini_token_iter(gemini_history, tier, gemini_system),
-                    transcript=None,
-                    send_lock=send_lock,
-                    commit_to_transcript=False,
-                ),
-                _stream_model(
-                    websocket, "GPT",
-                    lambda: _gpt_token_iter(gpt_history, tier, gpt_system),
-                    transcript=None,
-                    send_lock=send_lock,
-                    commit_to_transcript=False,
-                ),
-                _stream_model(
-                    websocket, "Grok",
-                    lambda: _grok_token_iter(grok_history, tier, grok_system),
-                    transcript=None,
-                    send_lock=send_lock,
-                    commit_to_transcript=False,
-                ),
-                _stream_model(
-                    websocket, "Claude",
-                    lambda: _claude_token_iter(claude_history, tier, claude_system),
-                    transcript=None,
-                    send_lock=send_lock,
-                    commit_to_transcript=False,
-                ),
-                _research_task(),
-                return_exceptions=True,
-            )
-            gemini_exec    = results[0] if isinstance(results[0], str) else f"[Gemini error: {results[0]}]"
-            gpt_exec       = results[1] if isinstance(results[1], str) else f"[GPT error: {results[1]}]"
-            grok_exec      = results[2] if isinstance(results[2], str) else f"[Grok error: {results[2]}]"
-            claude_r1_exec = results[3] if isinstance(results[3], str) else f"[Claude error: {results[3]}]"
-            perplexity_pre = results[4] if isinstance(results[4], str) else ""
-            gemini_text    = gemini_exec
-            gpt_text       = gpt_exec
-            grok_text      = grok_exec
-            claude_r1_text = claude_r1_exec
+        await asyncio.gather(
+            _emit_model_tokens("Gemini", gemini_text),
+            _emit_model_tokens("GPT",    gpt_text),
+            _emit_model_tokens("Grok",   grok_text),
+            _emit_model_tokens("Claude", claude_r1_text),
+        )
 
         transcript.add_model_message("Gemini", gemini_text,    round="round1")
         transcript.add_model_message("GPT",    gpt_text,       round="round1")
         transcript.add_model_message("Grok",   grok_text,      round="round1")
         transcript.add_model_message("Claude", claude_r1_text, round="round1")
 
-        # ── Perplexity audit (Phase 2) ────────────────────────────────────────
+        # ── Perplexity audit (Phase 2) with fallback ──────────────────────────
         await websocket.send_json({"type": "perplexity_thinking"})
         try:
-            audit_text = await asyncio.to_thread(
-                _call_with_retry,
-                lambda: perplexity_audit(
-                    {"gemini": gemini_text, "gpt": gpt_text, "grok": grok_text},
-                    research_text=perplexity_pre,
-                    tier=tier,
-                ),
-                "Perplexity-audit",
+            audit_text, factcheck_provider = await asyncio.to_thread(
+                audit_with_fallback,
+                {"gemini": gemini_text, "gpt": gpt_text,
+                 "grok": grok_text, "claude": claude_r1_text},
+                perplexity_pre,
+                tier,
             )
         except Exception as exc:
             audit_text = f"[Perplexity audit unavailable: {exc}]"
+            factcheck_provider = "emergency"
+        health.factcheck_model = factcheck_provider
+        health.factcheck_degraded = (factcheck_provider != "primary")
         transcript.add_model_message("Perplexity", audit_text, round="audit")
         await websocket.send_json({"type": "perplexity_complete", "content": audit_text})
 
-        # ── Generate synthesis annotations (read-only, sent after synthesis) ──
-        # Observations are generated now so they're ready to send immediately
-        # after synthesis_complete — no gate, no user response needed.
-        observations = await _generate_observations(
-            prompt=optimized_prompt,
-            gemini=gemini_text,
-            gpt=gpt_text,
-            grok=grok_text,
-            claude=claude_r1_text,
-            perplexity=audit_text,
-            tier=tier,
-        )
-
-        # ── Synthesis: Claude executor → (smart) advisor ─────────────────────
-        await websocket.send_json({"type": "synthesis_thinking"})
+        # ── Synthesis: route to analytical or factual model based on audit ────
+        synthesis_model_id, synthesis_route = select_synthesis_model(audit_text)
         synthesis_system = build_synthesis_prompt(
             output_type=output_type,
             perplexity_findings=audit_text,
@@ -1096,40 +1018,46 @@ async def session_websocket(websocket: WebSocket):
             },
             optimized_prompt=optimized_prompt,
         )
-        if mode == "smart":
-            try:
-                pack = await _call_with_retry_async(
-                    lambda: call_claude_smart_async(
-                        [{"role": "user", "content": prompt}],
-                        synthesis_system,
-                    ),
-                    "Claude-smart",
-                )
-                synthesis_text = str(pack.get("advisor_text", ""))
-            except Exception:
-                synthesis_text = ""
-            step = 48
-            for i in range(0, len(synthesis_text), step):
-                piece = synthesis_text[i : i + step]
-                async with send_lock:
-                    await websocket.send_json({"type": "token", "sender": "Claude", "token": piece})
-        else:
-            synthesis_text = await _stream_tokens(
-                websocket, "Claude",
-                lambda: _claude_token_iter(
-                    [{"role": "user", "content": prompt}], tier, synthesis_system
-                ),
-                send_lock=send_lock,
+        synthesis_messages = [{"role": "user", "content": prompt}]
+
+        await websocket.send_json({"type": "synthesis_thinking"})
+        try:
+            synthesis_text = await call_synthesis_async(
+                synthesis_model_id, synthesis_messages, synthesis_system, tier
             )
+            health.synthesis_model = synthesis_model_id
+            health.synthesis_routed = synthesis_route
+        except Exception as exc:
+            print(f"[synthesis] primary failed ({exc}) — using fallback", flush=True)
+            try:
+                synthesis_text = await call_synthesis_async(
+                    SYNTHESIS_FALLBACK, synthesis_messages, synthesis_system, tier
+                )
+                health.synthesis_model = SYNTHESIS_FALLBACK
+                health.synthesis_routed = f"{synthesis_route}_fallback"
+            except Exception as exc2:
+                synthesis_text = f"[Synthesis unavailable: {exc2}]"
+                health.synthesis_model = "emergency"
+                health.synthesis_routed = f"{synthesis_route}_fallback"
+
+        # Emit synthesis tokens
+        step = 48
+        for i in range(0, len(synthesis_text), step):
+            piece = synthesis_text[i : i + step]
+            async with send_lock:
+                await websocket.send_json({"type": "token", "sender": "Claude", "token": piece})
 
         transcript.add_model_message("Claude", synthesis_text, round="synthesis")
         await websocket.send_json({"type": "synthesis_complete", "content": synthesis_text})
-        # Send read-only synthesis annotations after synthesis (fire-and-forget, no gate).
-        if observations:
-            await websocket.send_json({
-                "type": "synthesis_annotations",
-                "annotations": observations,
-            })
+
+        print(f"[SESSION] {health.summary()}", flush=True)
+
+        # Send pipeline health annotations (read-only, after synthesis_complete).
+        await websocket.send_json({
+            "type": "synthesis_annotations",
+            "annotations": health.to_annotation(),
+            "pipeline_health": health.summary(),
+        })
         await websocket.send_json({"type": "session_complete"})
 
     except Exception as e:

--- a/backend/models/anthropic_client.py
+++ b/backend/models/anthropic_client.py
@@ -164,6 +164,35 @@ def ping() -> dict:
 
 # ── Intake fallback2 ─────────────────────────────────────────────────────────
 
+async def call_research_claude_async(
+    history: list, system: str, tier: str
+) -> tuple:
+    """
+    Call Claude for research with fallback to stable model.
+    Returns (response_text, availability_status).
+    availability_status: "primary" | "fallback" | "unavailable"
+    """
+    loop = asyncio.get_event_loop()
+
+    try:
+        if tier == "smart":
+            result = await call_claude_smart_async(history, system)
+            return result["advisor_text"], "primary"
+        else:
+            result = await loop.run_in_executor(
+                None, partial(call_claude, messages=history, tier="deep", system=system)
+            )
+            return result.content[0].text, "primary"
+    except Exception:
+        try:
+            result = await loop.run_in_executor(
+                None, partial(call_claude, messages=history, tier="smart", system=system)
+            )
+            return result.content[0].text, "fallback"
+        except Exception:
+            return "[Claude unavailable this session]", "unavailable"
+
+
 def call_intake_fallback2(prompt: str):
     """
     Intake fallback2 — Claude Haiku (Anthropic) as last-resort intake model.

--- a/backend/models/anthropic_client.py
+++ b/backend/models/anthropic_client.py
@@ -162,6 +162,50 @@ def ping() -> dict:
         return {"ok": False, "error": str(e)}
 
 
+# ── Intake fallback2 ─────────────────────────────────────────────────────────
+
+def call_intake_fallback2(prompt: str):
+    """
+    Intake fallback2 — Claude Haiku (Anthropic) as last-resort intake model.
+
+    Uses INTAKE_FALLBACK2 model ID from model_config.
+    Same IntakeDecision schema and system prompt as primary.
+
+    Args:
+        prompt: The user's raw prompt, or combined clarification turn string.
+
+    Returns:
+        IntakeDecision
+
+    Raises:
+        ValueError:   if response fails schema validation.
+        RuntimeError: on API failure.
+    """
+    import json
+    from backend.models.intake_decision import IntakeDecision
+    from backend.models.model_config import INTAKE_FALLBACK2
+    from backend.models.openai_client import _build_intake_system_prompt
+
+    system_prompt = _build_intake_system_prompt().strip()
+    response = _get_client().messages.create(
+        model=INTAKE_FALLBACK2,
+        max_tokens=512,
+        system=system_prompt,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    raw = response.content[0].text.strip()
+    # Strip markdown fences if present
+    if raw.startswith("```"):
+        parts = raw.split("```")
+        raw = parts[1].lstrip("json").strip() if len(parts) > 1 else raw
+    try:
+        return IntakeDecision.model_validate_json(raw)
+    except Exception as e:
+        raise ValueError(
+            f"Claude Haiku intake schema validation failed: {e}. Raw: {raw!r}"
+        )
+
+
 if __name__ == "__main__":
     result = ping()
     if result["ok"]:

--- a/backend/models/google_client.py
+++ b/backend/models/google_client.py
@@ -286,6 +286,49 @@ async def call_gemini_smart_async(messages: list, system=None) -> dict:
     )
 
 
+async def call_research_gemini_async(
+    history: list, system: str, tier: str
+) -> tuple:
+    """
+    Call Gemini for research with fallback to stable model.
+    Returns (response_text, availability_status).
+    availability_status: "primary" | "fallback" | "unavailable"
+
+    Smart tier: executor + advisor pattern.
+    Deep tier: single top-model call.
+    """
+    from backend.models.model_config import get_fallback_model
+    from backend.models.resilient_caller import call_with_fallback
+
+    async def _primary():
+        if tier == "smart":
+            result = await call_gemini_smart_async(history, system)
+            return result["advisor_text"]
+        else:
+            result = await loop_run(call_gemini, messages=history, tier="deep", system=system)
+            return result.text
+
+    async def _fallback():
+        fallback_id = get_fallback_model("gemini")
+        result = await loop_run(call_gemini, messages=history, tier="smart", system=system)
+        return result.text
+
+    loop = asyncio.get_event_loop()
+
+    async def loop_run(fn, **kwargs):
+        return await loop.run_in_executor(None, partial(fn, **kwargs))
+
+    try:
+        text = await _primary()
+        return text, "primary"
+    except Exception:
+        try:
+            text = await _fallback()
+            return text, "fallback"
+        except Exception:
+            return f"[Gemini unavailable this session]", "unavailable"
+
+
 def ping() -> dict:
     """
     Smoke test — sends a minimal message to confirm API key and connectivity.

--- a/backend/models/grok_client.py
+++ b/backend/models/grok_client.py
@@ -142,6 +142,39 @@ async def call_grok_smart_async(messages: list, system=None) -> dict:
     )
 
 
+async def call_research_grok_async(
+    history: list, system: str, tier: str
+) -> tuple:
+    """
+    Call Grok for research with fallback to stable model.
+    Returns (response_text, availability_status).
+    availability_status: "primary" | "fallback" | "unavailable"
+
+    Grok participates in both Smart and Deep tiers.
+    """
+    loop = asyncio.get_event_loop()
+
+    try:
+        if tier == "smart":
+            result = await loop.run_in_executor(
+                None, partial(call_grok_smart, history, system=system)
+            )
+            return result["advisor_text"], "primary"
+        else:
+            result = await loop.run_in_executor(
+                None, partial(call_grok, messages=history, tier="deep", system=system)
+            )
+            return result.choices[0].message.content, "primary"
+    except Exception:
+        try:
+            result = await loop.run_in_executor(
+                None, partial(call_grok, messages=history, tier="smart", system=system)
+            )
+            return result.choices[0].message.content, "fallback"
+        except Exception:
+            return "[Grok unavailable this session]", "unavailable"
+
+
 def ping() -> dict:
     """
     Smoke test — sends a minimal message to confirm API key and connectivity.

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -289,6 +289,38 @@ async def call_gpt_smart_async(messages: list, system=None) -> dict:
     )
 
 
+async def call_research_gpt_async(
+    history: list, system: str, tier: str
+) -> tuple:
+    """
+    Call GPT for research with fallback to stable model.
+    Returns (response_text, availability_status).
+    availability_status: "primary" | "fallback" | "unavailable"
+    """
+    loop = asyncio.get_event_loop()
+
+    try:
+        if tier == "smart":
+            result = await loop.run_in_executor(
+                None, partial(call_gpt_smart, history, system=system)
+            )
+            return result["advisor_text"], "primary"
+        else:
+            result = await loop.run_in_executor(
+                None, partial(call_gpt, messages=history, tier="deep", system=system)
+            )
+            return result.choices[0].message.content, "primary"
+    except Exception:
+        try:
+            from backend.models.model_config import get_fallback_model
+            result = await loop.run_in_executor(
+                None, partial(call_gpt, messages=history, tier="smart", system=system)
+            )
+            return result.choices[0].message.content, "fallback"
+        except Exception:
+            return "[GPT unavailable this session]", "unavailable"
+
+
 def ping() -> dict:
     """
     Smoke test — sends a minimal message to confirm API key and connectivity.

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -46,8 +46,10 @@ MODELS = {
     "deep":  "gpt-4o",
 }
 
-# Intake model — pinned separately from round-1 so it can be changed independently
-INTAKE_MODEL = os.getenv("INTAKE_MODEL", "gpt-4o-mini")
+from backend.models.model_config import INTAKE_PRIMARY
+
+# Intake model — sourced from model_config (env-overridable via INTAKE_PRIMARY)
+INTAKE_MODEL = INTAKE_PRIMARY
 
 # ── Intake system prompt ──────────────────────────────────────────────────────
 
@@ -167,6 +169,10 @@ def call_gpt4o_mini_intake(prompt: str) -> IntakeDecision:
     raise RuntimeError(
         "GPT-4o Mini intake unavailable after 3 attempts — please try again in a moment."
     ) from last_exc
+
+
+# Role-based alias used by intake fallback chain
+call_intake_primary = call_gpt4o_mini_intake
 
 
 # ── Round 1 call functions ────────────────────────────────────────────────────

--- a/backend/models/openrouter_client.py
+++ b/backend/models/openrouter_client.py
@@ -1,0 +1,102 @@
+"""
+backend/models/openrouter_client.py
+
+OpenRouter client for ai-roundtable v2.
+
+Provides access to open-weight models (Qwen, DeepSeek, Llama) via
+OpenRouter's OpenAI-compatible API. Used for:
+
+  - Intake fallback1: Qwen 2.5 72B (INTAKE_FALLBACK1)
+  - Synthesis fallback: Qwen 2.5 72B (SYNTHESIS_FALLBACK)
+
+All model IDs sourced from model_config — never hardcoded here.
+"""
+
+import os
+
+from openai import OpenAI
+
+_client = None
+
+
+def _get_client() -> OpenAI:
+    global _client
+    if _client is None:
+        _client = OpenAI(
+            api_key=os.getenv("OPENROUTER_API_KEY"),
+            base_url="https://openrouter.ai/api/v1",
+            default_headers={
+                "HTTP-Referer": "https://github.com/JSTcurious/ai-roundtable",
+                "X-Title": "ai-roundtable",
+            },
+        )
+    return _client
+
+
+def call_intake_fallback1(prompt: str):
+    """
+    Intake fallback1 — Qwen 2.5 72B via OpenRouter as secondary intake model.
+
+    Uses INTAKE_FALLBACK1 model ID from model_config.
+    Same IntakeDecision schema and system prompt as primary.
+
+    Args:
+        prompt: The user's raw prompt, or combined clarification turn string.
+
+    Returns:
+        IntakeDecision
+
+    Raises:
+        ValueError:   if response fails schema validation.
+        RuntimeError: on API failure.
+    """
+    from backend.models.intake_decision import IntakeDecision
+    from backend.models.model_config import INTAKE_FALLBACK1
+    from backend.models.openai_client import _build_intake_system_prompt
+
+    system_prompt = _build_intake_system_prompt().strip()
+    response = _get_client().chat.completions.create(
+        model=INTAKE_FALLBACK1,
+        max_tokens=512,
+        temperature=0.1,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user",   "content": prompt},
+        ],
+    )
+    raw = response.choices[0].message.content or ""
+    try:
+        return IntakeDecision.model_validate_json(raw)
+    except Exception as e:
+        raise ValueError(
+            f"Qwen intake schema validation failed: {e}. Raw: {raw!r}"
+        )
+
+
+def call_synthesis_fallback(
+    messages: list,
+    system: str,
+) -> str:
+    """
+    Synthesis fallback — Qwen 2.5 72B via OpenRouter.
+
+    Used when both SYNTHESIS_ANALYTICAL (Claude) and SYNTHESIS_FACTUAL (GPT)
+    fail. Open-weight model, different provider, 100% eval score on synthesis.
+
+    Args:
+        messages: list of {"role": str, "content": str} dicts
+        system:   synthesis system prompt string
+
+    Returns:
+        Synthesis text string.
+    """
+    from backend.models.model_config import SYNTHESIS_FALLBACK
+
+    full_messages = [{"role": "system", "content": system}] + messages
+    response = _get_client().chat.completions.create(
+        model=SYNTHESIS_FALLBACK,
+        max_tokens=4096,
+        messages=full_messages,
+    )
+    return response.choices[0].message.content or ""

--- a/backend/models/perplexity_client.py
+++ b/backend/models/perplexity_client.py
@@ -85,41 +85,178 @@ def research(prompt: str, tier: str = "quick") -> str:
     return response.choices[0].message.content.strip()
 
 
-def audit(model_responses: dict, research_text: str = "", tier: str = "quick") -> str:
+def _build_audit_prompt(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+) -> str:
+    """Build audit prompt with depth appropriate to tier."""
+    responses_block = "\n\n".join(
+        f"### {model}\n{text}"
+        for model, text in round1_responses.items()
+    )
+
+    base = f"""
+You are fact-checking AI model responses for accuracy and currency.
+
+## Round-1 Responses to Audit
+{responses_block}
+
+## Pre-Research Context
+{research_text or '(no pre-research available)'}
+"""
+
+    if tier == "deep":
+        return base + """
+## Deep Audit Instructions
+
+Be comprehensive and adversarial. Check everything.
+
+1. Verify EVERY specific factual claim (prices, dates, model versions,
+   statistics, named entities) across all four model responses.
+2. Map contradictions between models explicitly — when models disagree,
+   state which is correct, why, and cite a source.
+3. Research current practitioner consensus from live sources.
+4. Identify which round-1 models were most reliable on this topic.
+5. Flag your own confidence level on each correction.
+
+Return all four sections with full depth. Do not abbreviate.
+Cite specific sources for every correction — no vague references.
+"""
+    else:  # smart
+        return base + """
+## Smart Audit Instructions
+
+Be targeted and signal-focused. Prioritize the most impactful findings.
+
+1. Flag clearly wrong or outdated facts — focus on the most impactful errors.
+2. Surface the top 3 most important pieces of missing current information.
+3. Cite specific sources for every correction.
+4. Keep each section tight — synthesis needs clear signal, not volume.
+
+Return all four sections. Prioritize accuracy and clarity over completeness.
+"""
+
+
+def _build_audit_request(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+    model: str = None,
+) -> dict:
+    """Build the full Perplexity API request dict."""
+    from backend.models.model_config import FACTCHECK_PRIMARY, get_factcheck_max_tokens
+    return {
+        "model": model or FACTCHECK_PRIMARY,
+        "max_tokens": get_factcheck_max_tokens(tier),
+        "messages": [
+            {
+                "role": "user",
+                "content": _build_audit_prompt(round1_responses, research_text, tier),
+            }
+        ],
+    }
+
+
+def _call_perplexity_audit(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+    model: str = None,
+) -> str:
+    """Call Perplexity audit API with the given model."""
+    req = _build_audit_request(round1_responses, research_text, tier, model=model)
+    response = _get_client().chat.completions.create(**req)
+    return response.choices[0].message.content.strip()
+
+
+def _call_gpt_audit_with_web_search(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+) -> str:
     """
-    Phase 2 — Cross-check Gemini + GPT responses against live web research.
+    GPT fallback audit with web search tool — used only when Perplexity is down.
+    Cross-provider last resort: different grounding architecture, lower reliability.
+    """
+    from openai import OpenAI
+    from backend.models.model_config import FACTCHECK_FALLBACK2, get_factcheck_max_tokens
+    import os
+
+    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    prompt = _build_audit_prompt(round1_responses, research_text, tier)
+    prompt += "\n\nNote: You are acting as fact-checker. Search the web to verify claims."
+
+    response = client.chat.completions.create(
+        model=FACTCHECK_FALLBACK2,
+        max_tokens=get_factcheck_max_tokens(tier),
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def audit_with_fallback(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+) -> tuple:
+    """
+    Run Perplexity audit with fallback chain.
+    Returns (audit_text, provider_used).
+
+    Chain:
+        Primary:   Perplexity Sonar Pro  (FACTCHECK_PRIMARY)
+        Fallback1: Perplexity Sonar      (FACTCHECK_FALLBACK1, same grounding)
+        Fallback2: GPT-5.4 + web search  (FACTCHECK_FALLBACK2, cross-provider)
+        Emergency: Degraded notice string (never raises)
+
+    Both Perplexity tiers use the same Smart/Deep audit prompt.
+    """
+    from backend.models.resilient_caller import call_with_fallback as _call_with_fallback
+    from backend.models.model_config import FACTCHECK_PRIMARY, FACTCHECK_FALLBACK1
+
+    def _emergency_factcheck() -> str:
+        return (
+            "[Fact-check unavailable — all fact-check providers failed. "
+            "Synthesis is based on round-1 model responses only. "
+            "Apply additional skepticism to all factual claims. "
+            "Verify key facts against official sources before acting.]"
+        )
+
+    return _call_with_fallback(
+        primary_fn=lambda: _call_perplexity_audit(
+            round1_responses, research_text, tier,
+            model=FACTCHECK_PRIMARY,
+        ),
+        fallback_fns=[
+            lambda: _call_perplexity_audit(
+                round1_responses, research_text, tier,
+                model=FACTCHECK_FALLBACK1,
+            ),
+            lambda: _call_gpt_audit_with_web_search(
+                round1_responses, research_text, tier,
+            ),
+        ],
+        emergency_fn=_emergency_factcheck,
+        role="factcheck",
+    )
+
+
+def audit(model_responses: dict, research_text: str = "", tier: str = "smart") -> str:
+    """
+    Phase 2 — Cross-check model responses against live web research.
+    Legacy single-call interface — use audit_with_fallback() for resilience.
 
     Args:
-        model_responses: {"gemini": str, "gpt": str}
+        model_responses: {"gemini": str, "gpt": str, "grok": str, ...}
         research_text:   findings from research() (Phase 1)
-        tier:            "quick" | "deep"
+        tier:            "smart" | "deep"
 
     Returns:
         Structured audit string with citations and dates.
     """
-    model = MODELS.get(tier, MODELS["quick"])
-
-    gemini_response = model_responses.get("gemini", "")
-    gpt_response = model_responses.get("gpt", "")
-
-    audit_prompt = (
-        f"You have live web research and two AI model responses on this topic.\n\n"
-        f"Live research you gathered:\n{research_text or '(no pre-research available)'}\n\n"
-        f"Gemini's response:\n{gemini_response or '(not available)'}\n\n"
-        f"GPT's response:\n{gpt_response or '(not available)'}\n\n"
-        f"Identify:\n"
-        f"1. Facts that are outdated or incorrect per current web research\n"
-        f"2. Important current information neither model mentioned\n"
-        f"3. Tools or courses that have changed in relevance recently\n"
-        f"4. What the current practitioner community actually recommends right now\n\n"
-        f"Return a structured audit with citations and dates for all sources."
-    )
-
-    response = _get_client().chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": audit_prompt}],
-    )
-    return response.choices[0].message.content.strip()
+    from backend.models.model_config import FACTCHECK_PRIMARY
+    return _call_perplexity_audit(model_responses, research_text, tier, model=FACTCHECK_PRIMARY)
 
 
 def ping() -> dict:

--- a/backend/models/pipeline_health.py
+++ b/backend/models/pipeline_health.py
@@ -1,0 +1,64 @@
+"""
+backend/models/pipeline_health.py
+
+PipelineHealth — tracks which model handled each pipeline stage in a session.
+
+Accumulated throughout a session and sent to the frontend as
+synthesis_annotations after session_complete. Only noteworthy events
+are shown — healthy sessions produce no annotations.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PipelineHealth:
+    """Tracks which model handled each pipeline stage in a session."""
+    intake_model:        str  = "unknown"
+    intake_degraded:     bool = False
+    research_models:     dict = field(default_factory=dict)
+    # {"gemini": "primary"|"fallback"|"unavailable", ...}
+    factcheck_model:     str  = "unknown"
+    factcheck_degraded:  bool = False
+    synthesis_model:     str  = "unknown"
+    synthesis_routed:    str  = "analytical"  # analytical | factual | *_fallback
+
+    def summary(self) -> str:
+        """One-line summary for logging."""
+        degraded = []
+        if self.intake_degraded:
+            degraded.append("intake")
+        if self.factcheck_degraded:
+            degraded.append("factcheck")
+        unavailable = [
+            lab for lab, status in self.research_models.items()
+            if status == "unavailable"
+        ]
+        if unavailable:
+            degraded.append(f"research({','.join(unavailable)})")
+        status = "degraded" if degraded else "healthy"
+        return f"Pipeline {status}: synthesis={self.synthesis_routed}"
+
+    def to_annotation(self) -> list:
+        """
+        Format as annotation lines for the read-only UI panel.
+        Only shows noteworthy events — healthy sessions show nothing.
+        """
+        lines = []
+        if self.intake_degraded:
+            lines.append("⚠️ Intake fell back from primary model")
+        for lab, status in self.research_models.items():
+            if status == "unavailable":
+                lines.append(f"⚠️ {lab.capitalize()} was unavailable this session")
+            elif status == "fallback":
+                lines.append(f"ℹ️ {lab.capitalize()} used fallback model")
+        if self.factcheck_degraded:
+            lines.append(f"⚠️ Perplexity unavailable — used {self.factcheck_model}")
+        if "fallback" in self.synthesis_routed:
+            lines.append("⚠️ Synthesis used fallback model")
+        elif self.synthesis_routed == "factual":
+            lines.append(
+                "ℹ️ Synthesis routed to factual model — "
+                "Perplexity data contradicted round-1 responses"
+            )
+        return lines

--- a/backend/models/resilient_caller.py
+++ b/backend/models/resilient_caller.py
@@ -1,0 +1,95 @@
+"""
+backend/models/resilient_caller.py
+
+Generic retry + fallback wrapper for all model calls.
+All function names are role-based — no model names in signatures.
+"""
+
+import logging
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_PATTERNS = [
+    "503", "429", "rate limit", "unavailable",
+    "overloaded", "capacity", "too many requests",
+]
+
+
+def is_retryable(exc: Exception) -> bool:
+    msg = str(exc).lower()
+    return any(pattern in msg for pattern in RETRYABLE_PATTERNS)
+
+
+def call_with_retry(
+    fn: Callable,
+    max_attempts: int = 3,
+    base_delay: float = 2.0,
+    role: str = "unknown",
+) -> Any:
+    """
+    Call fn with exponential backoff retry on retryable errors.
+    Raises last exception after max_attempts exhausted.
+    Non-retryable errors raise immediately.
+    """
+    last_exc = None
+    for attempt in range(max_attempts):
+        try:
+            return fn()
+        except Exception as exc:
+            if is_retryable(exc):
+                last_exc = exc
+                delay = base_delay * (2 ** attempt)
+                logger.warning(
+                    f"{role}: attempt {attempt + 1}/{max_attempts} failed "
+                    f"({exc.__class__.__name__}: {exc}). "
+                    f"Retrying in {delay}s..."
+                )
+                if attempt < max_attempts - 1:
+                    time.sleep(delay)
+                continue
+            raise  # Non-retryable — raise immediately
+    raise RuntimeError(
+        f"{role}: unavailable after {max_attempts} attempts"
+    ) from last_exc
+
+
+def call_with_fallback(
+    primary_fn: Callable,
+    fallback_fns: list,
+    emergency_fn: Optional[Callable] = None,
+    role: str = "unknown",
+    primary_attempts: int = 3,
+    fallback_attempts: int = 2,
+) -> Any:
+    """
+    Try primary_fn with retries, then each fallback_fn with retries.
+    If all fail and emergency_fn provided, call it (no retry, never raises).
+    If all fail and no emergency_fn, raise last exception.
+
+    Returns (result, label) where label is "primary", "fallback1", etc.
+    """
+    fns_and_labels = (
+        [(primary_fn, "primary")] +
+        [(fn, f"fallback{i+1}") for i, fn in enumerate(fallback_fns)]
+    )
+
+    last_exc = None
+    for fn, label in fns_and_labels:
+        attempts = primary_attempts if label == "primary" else fallback_attempts
+        try:
+            result = call_with_retry(fn, max_attempts=attempts, role=f"{role}/{label}")
+            if label != "primary":
+                logger.info(f"{role}: succeeded on {label}")
+            return result, label  # Return result AND which label was used
+        except Exception as exc:
+            logger.warning(f"{role}: {label} exhausted — {exc}")
+            last_exc = exc
+            continue
+
+    if emergency_fn:
+        logger.warning(f"{role}: all providers failed — using emergency fallback")
+        return emergency_fn(), "emergency"
+
+    raise RuntimeError(f"{role}: all providers failed") from last_exc

--- a/backend/router.py
+++ b/backend/router.py
@@ -247,6 +247,7 @@ FACTUAL_CONTRADICTION_SIGNALS = [
     "as of 2026", "as of april 2026", "current pricing", "launched",
     "released", "no longer available", "wrong", "inaccurate",
     "this is false", "this is incorrect", "has been superseded",
+    "contradicts", "disagrees", "not accurate", "factually wrong",
 ]
 
 

--- a/backend/router.py
+++ b/backend/router.py
@@ -28,6 +28,9 @@ from backend.models.model_config import (
     get_advisor_model,
     get_fallback_model,
     get_all_labs,
+    SYNTHESIS_ANALYTICAL,
+    SYNTHESIS_FACTUAL,
+    SYNTHESIS_FALLBACK,
 )
 from backend.models.perplexity_client import MODELS as PERPLEXITY_MODELS
 
@@ -237,6 +240,36 @@ def _format_round1_responses(responses: dict) -> str:
     for model, text in responses.items():
         lines.append(f"{model.capitalize()}'s analysis:\n{text or '(not available)'}")
     return "\n\n".join(lines) if lines else "(no round-1 responses available)"
+
+
+FACTUAL_CONTRADICTION_SIGNALS = [
+    "retired", "deprecated", "replaced by", "incorrect", "outdated",
+    "as of 2026", "as of april 2026", "current pricing", "launched",
+    "released", "no longer available", "wrong", "inaccurate",
+    "this is false", "this is incorrect", "has been superseded",
+]
+
+
+def perplexity_contradicts_round1(audit_text: str) -> bool:
+    """
+    Return True when Perplexity audit signals it is contradicting
+    round-1 model responses on verifiable current facts.
+
+    When True: route synthesis to SYNTHESIS_FACTUAL (GPT-5.4)
+    When False: route to SYNTHESIS_ANALYTICAL (Claude Opus 4.7)
+    """
+    audit_lower = audit_text.lower()
+    return any(signal in audit_lower for signal in FACTUAL_CONTRADICTION_SIGNALS)
+
+
+def select_synthesis_model(audit_text: str) -> tuple:
+    """
+    Route synthesis to appropriate model. Returns (model_id, route_name).
+    route_name is "analytical" or "factual" — used in PipelineHealth.
+    """
+    if perplexity_contradicts_round1(audit_text):
+        return SYNTHESIS_FACTUAL, "factual"
+    return SYNTHESIS_ANALYTICAL, "analytical"
 
 
 def get_tier_config(tier: str) -> dict:

--- a/frontend/src/components/IntakeFlow.jsx
+++ b/frontend/src/components/IntakeFlow.jsx
@@ -17,16 +17,50 @@ import Header from "./common/Header";
 const API_BASE = process.env.REACT_APP_API_URL || "http://localhost:8000";
 
 const TIER_LABELS = {
-  quick: "⚡ Quick",
   smart: "⚖ Smart",
   deep:  "🔍 Deep",
 };
 
-const TIER_DESCRIPTIONS = {
-  quick: "Single executor per model · fastest · good for gut checks and brainstorms",
-  smart: "Executor + advisor per model · near-Deep quality · recommended for most sessions",
-  deep:  "Flagship models throughout · maximum depth · best for reports and critical decisions",
-};
+/**
+ * Modal confirming the user understands the cost/time trade-off of upgrading to Deep.
+ */
+function DeepConfirmationModal({ onConfirm, onCancel }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="deep-modal-title"
+    >
+      <div className="w-full max-w-sm rounded-xl border border-[#2a2a2a] bg-[#1e1e1e] p-6 shadow-xl">
+        <h2 id="deep-modal-title" className="mb-2 text-base font-semibold text-[#e8e8e8]">
+          Upgrade to Deep?
+        </h2>
+        <p className="mb-5 text-sm leading-relaxed text-[#888888]">
+          Sessions take longer (10–20 min) and cost significantly more.
+          Deep uses flagship models throughout — best for reports and critical decisions.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-[#2a2a2a] bg-[#0d0d0d] px-4 py-2 text-sm text-[#888888] hover:text-[#e8e8e8] focus:outline-none"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-lg px-4 py-2 text-sm font-bold focus:outline-none"
+            style={{ background: "#F5A623", color: "#0d0d0d" }}
+          >
+            Upgrade to Deep
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 /**
  * @param {Object}   props
@@ -42,8 +76,8 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
   const [answer, setAnswer] = useState("");
   const [submittingAnswer, setSubmittingAnswer] = useState(false);
   const [config, setConfig] = useState(null);
-  /** Whether the inline tier override panel is open */
-  const [showOverride, setShowOverride] = useState(false);
+  /** Whether the Deep upgrade confirmation modal is open */
+  const [showDeepConfirm, setShowDeepConfirm] = useState(false);
   const [tierChoice, setTierChoice] = useState("smart");
   const [error, setError] = useState(null);
   const answerRef = useRef(null);
@@ -220,39 +254,23 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
                 </div>
                 <p className="mt-1.5 text-sm text-[#888888]">{config.reasoning}</p>
               </div>
-              <button
-                type="button"
-                onClick={() => setShowOverride((v) => !v)}
-                className="shrink-0 text-sm text-[#888888] underline-offset-2 hover:text-[#e8e8e8] focus:outline-none"
-              >
-                {showOverride ? "Close" : "Change"}
-              </button>
+              {tierChoice === "smart" && (
+                <button
+                  type="button"
+                  onClick={() => setShowDeepConfirm(true)}
+                  className="shrink-0 text-sm text-[#F5A623] underline-offset-2 hover:opacity-80 focus:outline-none"
+                >
+                  Upgrade to Deep ↑
+                </button>
+              )}
             </div>
 
-            {/* Inline tier override */}
-            {showOverride && (
-              <div className="space-y-3 rounded-lg border border-[#2a2a2a] bg-[#1e1e1e] px-4 py-4">
-                <p className="text-xs font-medium uppercase tracking-wide text-[#888888]">Override tier</p>
-                <div className="flex gap-3">
-                  {["quick", "smart", "deep"].map((id) => (
-                    <button
-                      key={id}
-                      type="button"
-                      onClick={() => { setTierChoice(id); setShowOverride(false); }}
-                      className={`min-w-0 flex-1 rounded-lg border px-3 py-2.5 text-center text-sm font-medium transition-colors focus:outline-none ${
-                        tierChoice === id
-                          ? "border-[#6B6B6B] bg-[#2a2a2a] text-[#e8e8e8]"
-                          : "border-[#2a2a2a] bg-[#0d0d0d] text-[#888888] hover:border-[#6B6B6B]"
-                      }`}
-                    >
-                      {TIER_LABELS[id]}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs leading-relaxed text-[#666666]">
-                  {TIER_DESCRIPTIONS[tierChoice]}
-                </p>
-              </div>
+            {/* Deep upgrade confirmation modal */}
+            {showDeepConfirm && (
+              <DeepConfirmationModal
+                onConfirm={() => { setTierChoice("deep"); setShowDeepConfirm(false); }}
+                onCancel={() => setShowDeepConfirm(false)}
+              />
             )}
 
             {/* Confirm */}

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,350 @@
+"""
+tests/test_resilience.py
+
+Tests for the Task B resilience layer.
+
+Coverage:
+    - Intake fallback chain (primary → fallback1 → fallback2 → passthrough)
+    - Synthesis router: FACTUAL_CONTRADICTION_SIGNALS detection
+    - Research availability status tuples
+    - Factcheck fallback chain (audit_with_fallback)
+    - PipelineHealth: annotations for healthy and degraded sessions
+    - resilient_caller: call_with_fallback labels
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ── Synthesis router ──────────────────────────────────────────────────────────
+
+class TestSynthesisRouter:
+    """select_synthesis_model() routes based on Perplexity contradiction signals."""
+
+    def _route(self, audit_text: str):
+        from backend.router import select_synthesis_model
+        return select_synthesis_model(audit_text)
+
+    def test_clean_audit_routes_analytical(self):
+        model_id, route = self._route("All models agreed on the key points.")
+        assert route == "analytical"
+
+    def test_contradicts_signal_routes_factual(self):
+        model_id, route = self._route(
+            "Perplexity contradicts the round-1 responses on pricing."
+        )
+        assert route == "factual"
+
+    def test_incorrect_signal_routes_factual(self):
+        model_id, route = self._route(
+            "GPT's claim is incorrect according to current data."
+        )
+        assert route == "factual"
+
+    def test_outdated_signal_routes_factual(self):
+        model_id, route = self._route(
+            "This information appears to be outdated — the API changed in 2024."
+        )
+        assert route == "factual"
+
+    def test_factually_wrong_routes_factual(self):
+        model_id, route = self._route(
+            "The statistic cited is factually wrong."
+        )
+        assert route == "factual"
+
+    def test_empty_audit_routes_analytical(self):
+        model_id, route = self._route("")
+        assert route == "analytical"
+
+    def test_analytical_route_returns_model_id(self):
+        from backend.models.model_config import SYNTHESIS_ANALYTICAL
+        model_id, route = self._route("Models agreed across the board.")
+        assert model_id == SYNTHESIS_ANALYTICAL
+
+    def test_factual_route_returns_model_id(self):
+        from backend.models.model_config import SYNTHESIS_FACTUAL
+        model_id, route = self._route("This contradicts current data.")
+        assert model_id == SYNTHESIS_FACTUAL
+
+    def test_disagrees_signal_routes_factual(self):
+        model_id, route = self._route(
+            "Perplexity disagrees with Gemini's version numbers."
+        )
+        assert route == "factual"
+
+    def test_not_accurate_signal_routes_factual(self):
+        model_id, route = self._route(
+            "The claim is not accurate based on live sources."
+        )
+        assert route == "factual"
+
+
+# ── PipelineHealth ────────────────────────────────────────────────────────────
+
+class TestPipelineHealth:
+    """PipelineHealth emits annotations only for noteworthy events."""
+
+    def _make(self, **kwargs):
+        from backend.models.pipeline_health import PipelineHealth
+        h = PipelineHealth()
+        for k, v in kwargs.items():
+            setattr(h, k, v)
+        return h
+
+    def test_healthy_session_produces_no_annotations(self):
+        h = self._make(
+            intake_degraded=False,
+            research_models={"gemini": "primary", "gpt": "primary",
+                             "grok": "primary", "claude": "primary"},
+            factcheck_degraded=False,
+            synthesis_routed="analytical",
+        )
+        assert h.to_annotation() == []
+
+    def test_intake_degraded_appears_in_annotations(self):
+        h = self._make(intake_degraded=True)
+        annotations = h.to_annotation()
+        assert any("intake" in a.lower() for a in annotations)
+
+    def test_research_unavailable_appears_in_annotations(self):
+        h = self._make(research_models={"gemini": "unavailable", "gpt": "primary",
+                                        "grok": "primary", "claude": "primary"})
+        annotations = h.to_annotation()
+        assert any("gemini" in a.lower() for a in annotations)
+
+    def test_research_fallback_appears_in_annotations(self):
+        h = self._make(research_models={"grok": "fallback", "gemini": "primary",
+                                        "gpt": "primary", "claude": "primary"})
+        annotations = h.to_annotation()
+        assert any("grok" in a.lower() for a in annotations)
+
+    def test_factcheck_degraded_appears_in_annotations(self):
+        h = self._make(factcheck_degraded=True, factcheck_model="gpt-4o")
+        annotations = h.to_annotation()
+        assert any("perplexity" in a.lower() or "fact" in a.lower()
+                   for a in annotations)
+
+    def test_synthesis_fallback_appears_in_annotations(self):
+        h = self._make(synthesis_routed="analytical_fallback")
+        annotations = h.to_annotation()
+        assert any("synthesis" in a.lower() or "fallback" in a.lower()
+                   for a in annotations)
+
+    def test_synthesis_factual_route_appears_in_annotations(self):
+        h = self._make(synthesis_routed="factual")
+        annotations = h.to_annotation()
+        assert any("factual" in a.lower() or "perplexity" in a.lower()
+                   for a in annotations)
+
+    def test_summary_healthy(self):
+        h = self._make(
+            research_models={"gemini": "primary", "gpt": "primary",
+                             "grok": "primary", "claude": "primary"},
+            synthesis_routed="analytical",
+        )
+        assert "healthy" in h.summary().lower()
+
+    def test_summary_degraded_when_research_unavailable(self):
+        h = self._make(research_models={"gemini": "unavailable", "gpt": "primary",
+                                        "grok": "primary", "claude": "primary"})
+        assert "degraded" in h.summary().lower()
+
+    def test_summary_degraded_when_factcheck_degraded(self):
+        h = self._make(factcheck_degraded=True)
+        assert "degraded" in h.summary().lower()
+
+    def test_multiple_degraded_events_all_appear(self):
+        h = self._make(
+            intake_degraded=True,
+            research_models={"gemini": "unavailable", "gpt": "primary",
+                             "grok": "primary", "claude": "primary"},
+            factcheck_degraded=True,
+        )
+        annotations = h.to_annotation()
+        assert len(annotations) >= 3
+
+
+# ── resilient_caller ──────────────────────────────────────────────────────────
+
+class TestResilientCaller:
+    """call_with_fallback returns (result, label) and walks the chain correctly."""
+
+    def _call(self, primary_fn, fallback_fns=None, emergency_fn=None):
+        from backend.models.resilient_caller import call_with_fallback
+        return call_with_fallback(
+            primary_fn=primary_fn,
+            fallback_fns=fallback_fns or [],
+            emergency_fn=emergency_fn,
+            role="test",
+            primary_attempts=1,
+            fallback_attempts=1,
+        )
+
+    def test_primary_success_returns_primary_label(self):
+        result, label = self._call(primary_fn=lambda: "ok")
+        assert result == "ok"
+        assert label == "primary"
+
+    def test_primary_failure_tries_fallback(self):
+        result, label = self._call(
+            primary_fn=lambda: (_ for _ in ()).throw(RuntimeError("down")),
+            fallback_fns=[lambda: "fallback_result"],
+        )
+        assert result == "fallback_result"
+        assert "fallback" in label
+
+    def test_all_fallbacks_fail_uses_emergency(self):
+        result, label = self._call(
+            primary_fn=lambda: (_ for _ in ()).throw(RuntimeError("p")),
+            fallback_fns=[
+                lambda: (_ for _ in ()).throw(RuntimeError("f1")),
+            ],
+            emergency_fn=lambda: "emergency_result",
+        )
+        assert result == "emergency_result"
+        assert label == "emergency"
+
+    def test_no_emergency_raises_on_all_failure(self):
+        from backend.models.resilient_caller import call_with_fallback
+        with pytest.raises(Exception):
+            call_with_fallback(
+                primary_fn=lambda: (_ for _ in ()).throw(RuntimeError("p")),
+                fallback_fns=[lambda: (_ for _ in ()).throw(RuntimeError("f"))],
+                emergency_fn=None,
+                role="test",
+                primary_attempts=1,
+                fallback_attempts=1,
+            )
+
+    def test_second_fallback_used_when_first_fails(self):
+        result, label = self._call(
+            primary_fn=lambda: (_ for _ in ()).throw(RuntimeError("p")),
+            fallback_fns=[
+                lambda: (_ for _ in ()).throw(RuntimeError("f1")),
+                lambda: "fallback2_result",
+            ],
+        )
+        assert result == "fallback2_result"
+        assert "fallback" in label
+
+
+# ── Research availability statuses ────────────────────────────────────────────
+
+class TestResearchAvailabilityStatus:
+    """
+    call_research_*_async() return (text, status) where status is
+    "primary" | "fallback" | "unavailable".
+    """
+
+    def _make_gemini_response(self, text="response"):
+        resp = MagicMock()
+        resp.text = text
+        return resp
+
+    def test_gemini_returns_tuple(self):
+        """call_research_gemini_async returns a 2-tuple."""
+        with patch("backend.models.google_client.call_gemini",
+                   return_value=self._make_gemini_response()):
+            import asyncio
+            from backend.models.google_client import call_research_gemini_async
+            result = asyncio.get_event_loop().run_until_complete(
+                call_research_gemini_async(
+                    [{"role": "user", "content": "test"}],
+                    "system",
+                    "smart",
+                )
+            )
+            assert isinstance(result, tuple)
+            assert len(result) == 2
+            text, status = result
+            assert isinstance(text, str)
+            assert status in ("primary", "fallback", "unavailable")
+
+    def test_gpt_returns_tuple(self):
+        """call_research_gpt_async returns a 2-tuple."""
+        msg = MagicMock()
+        msg.content = "gpt_response"
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+
+        with patch("backend.models.openai_client.call_gpt", return_value=resp):
+            import asyncio
+            from backend.models.openai_client import call_research_gpt_async
+            result = asyncio.get_event_loop().run_until_complete(
+                call_research_gpt_async(
+                    [{"role": "user", "content": "test"}],
+                    "system",
+                    "smart",
+                )
+            )
+            assert isinstance(result, tuple)
+            assert len(result) == 2
+
+    def test_grok_returns_tuple(self):
+        """call_research_grok_async returns a 2-tuple."""
+        msg = MagicMock()
+        msg.content = "grok_response"
+        choice = MagicMock()
+        choice.message = msg
+        resp = MagicMock()
+        resp.choices = [choice]
+
+        with patch("backend.models.grok_client.call_grok", return_value=resp):
+            import asyncio
+            from backend.models.grok_client import call_research_grok_async
+            result = asyncio.get_event_loop().run_until_complete(
+                call_research_grok_async(
+                    [{"role": "user", "content": "test"}],
+                    "system",
+                    "smart",
+                )
+            )
+            assert isinstance(result, tuple)
+            assert len(result) == 2
+
+    def test_gemini_unavailable_returns_unavailable_status(self):
+        """When Gemini raises, research returns (error_text, 'unavailable')."""
+        with patch("backend.models.google_client.call_gemini",
+                   side_effect=RuntimeError("API down")):
+            import asyncio
+            from backend.models.google_client import call_research_gemini_async
+            text, status = asyncio.get_event_loop().run_until_complete(
+                call_research_gemini_async(
+                    [{"role": "user", "content": "test"}],
+                    "system",
+                    "smart",
+                )
+            )
+            assert status == "unavailable"
+            assert isinstance(text, str)
+
+
+# ── Intake passthrough ────────────────────────────────────────────────────────
+
+class TestIntakePassthrough:
+    """_intake_passthrough always returns a valid IntakeDecision with tier=smart."""
+
+    def test_passthrough_returns_intake_decision(self):
+        from backend.intake import _intake_passthrough
+        from backend.models.openai_client import IntakeDecision
+        result = _intake_passthrough("any prompt")
+        assert isinstance(result, IntakeDecision)
+
+    def test_passthrough_tier_is_smart(self):
+        from backend.intake import _intake_passthrough
+        result = _intake_passthrough("any prompt")
+        assert result.tier == "smart"
+
+    def test_passthrough_never_raises(self):
+        from backend.intake import _intake_passthrough
+        # Should not raise even on weird input
+        result = _intake_passthrough("")
+        assert result is not None
+
+    def test_passthrough_needs_no_clarification(self):
+        from backend.intake import _intake_passthrough
+        result = _intake_passthrough("any prompt")
+        assert result.needs_clarification is False


### PR DESCRIPTION
## What
Full resilience layer across all four pipeline stages.
Requires feat/model-config-foundation (already merged).

## Parts shipped
1. resilient_caller.py — generic retry + fallback wrapper
2. Intake fallback chain — GPT-4o Mini → Qwen 2.5 72B → Claude Haiku → passthrough
3. Synthesis router — analytical (Claude) vs factual (GPT) routing
4. Research per-lab resilience — executor → fallback → skip placeholder
5. Factcheck Smart/Deep audit depth + Sonar Pro → Sonar → GPT web search fallback
6. PipelineHealth signal — tracks degradation per stage, shown in annotation panel
7. Frontend — Deep upgrade button + confirmation modal, quick tier removed
8. 34 new resilience tests (176 total)

## Bug fixed
mode = tier_config.get("mode", "single") was broken — now corrected

## Architecture
- Smart: executor + advisor per lab
- Deep: user opt-in only via confirmation modal
- Intake always returns smart tier
- Perplexity stays primary fact-checker with Sonar fallback before cross-provider