### PR TITLE
docs(decisions): ADR 002 synthesizer selection + ADR 003 intake model selection

### DIFF
--- a/docs/decisions/002-synthesizer-selection.md
+++ b/docs/decisions/002-synthesizer-selection.md
@@ -1,130 +1,144 @@
 # ADR 002: Synthesizer Model Selection
 
-**Status:** Accepted
+**Status:** Accepted  
 **Date:** 2026-04-17
 
 ## Context
 
-ai-roundtable's synthesis step is Claude's highest-stakes call. The
-synthesizer receives four round-1 responses, a Perplexity live-web audit, and
-the chair's session config, then produces the final deliverable the user takes
-away. It must:
+ai-roundtable uses a single model to synthesize round-1 research responses from
+four labs (Gemini, GPT, Grok, Claude) plus a Perplexity fact-check audit into a
+final deliverable.
 
-1. Follow a strict source trust hierarchy — Perplexity's live-verified facts
-   beat training-data claims from round-1 models.
-2. State contradictions explicitly rather than blending conflicting figures.
-3. Attribute every material claim to its source.
-4. Apply four confidence tags (`[VERIFIED]`, `[LIKELY]`, `[UNCERTAIN]`,
-   `[DEFER]`) to make epistemic state legible.
-5. End with concrete actionable next steps.
+Two failure modes were observed during development:
 
-A parallel failure mode motivated this evaluation: Claude's trained refusal
-behavior for post-cutoff dates was overriding system prompt instructions. When
-Perplexity provided live-verified pricing for a newly released model and a
-round-1 response gave stale (but confident) training-data pricing, Claude was
-presenting the stale figure — calling the Perplexity data unverifiable rather
-than treating it as authoritative. This is the "failing case" captured in
-synthesizer eval Test 1.
+1. **Post-cutoff refusal** — Claude refused to incorporate Perplexity's
+   live-cited data about post-training-cutoff events (model releases, pricing,
+   deprecations), calling verified data "fabricated information."
 
-## Evaluation
+2. **Cascading hallucination** — Without explicit skepticism rules, synthesis
+   would treat round-1 model claims as established facts rather than unverified
+   assertions requiring attribution.
 
-The `experiments/synthesizer_eval/` harness ran three fixed tests across six
-candidates (v1) and five candidates (v2 with cost analysis):
+An empirical evaluation harness was built and run against six candidates
+(see `experiments/synthesizer_eval/`): Claude Opus 4.7, Claude Sonnet 4.6,
+Claude Haiku 4.5, GPT-4o, Qwen 2.5 72B, and Llama 3.3 70B.
 
-### v1 Results (6 candidates, no token counting)
+## Evaluation Results
 
-| Candidate | Score /90 | Test 1 (factual) | Notes |
-|-----------|-----------|-----------------|-------|
-| Claude Opus 4.7 | **89** | ✓ | Full tag adoption; near-perfect |
-| Qwen 2.5 72B | 82 | ✓ | Solid all-round |
-| Llama 3.3 70B | 82 | ✓ | Solid; slightly less tag discipline |
-| GPT-4o | 80 | ✓ | Good; less tag differentiation |
-| Gemini 2.5 Pro | 78 | ✓ | Test 2 truncated |
-| DeepSeek V3 | 60 | ✗ | **CRITICAL FAILURE** — Test 3 output corrupted with unrelated content |
+Tests used fixed inputs — identical round-1 responses and Perplexity audit —
+across all candidates. Three tests:
 
-### v2 Evaluation Dimensions (per test, 1–5 each, max 30)
+- **T1 — Factual (post-cutoff pricing):** The failure case. Perplexity data
+  contradicts round-1 stale pricing. Synthesis must defer to Perplexity.
+- **T2 — Analytical (RLHF alignment):** The working case. No post-cutoff data
+  conflict. Tests attribution, depth, and confidence tag adoption.
+- **T3 — Domain technical (ISO-NE offshore wind):** The showcase case. Dense
+  domain knowledge with no factual contradictions. Tests synthesis narrative quality.
 
-1. **Factual grounding** — uses Perplexity's verified data as primary source
-2. **Attribution** — every claim attributed to a named source
-3. **Contradiction handling** — states conflicts explicitly, does not blend
-4. **Analytical depth** — adds expert perspective beyond summarizing
-5. **Tag adoption** — uses `[VERIFIED]`/`[LIKELY]`/`[UNCERTAIN]`/`[DEFER]`
-6. **Actionability** — ends with 3 concrete actionable next steps
+Six scoring dimensions per test (1–5 each, max 30/test, max 90 total):
+factual grounding, attribution, contradiction handling, analytical depth,
+tag adoption (`[VERIFIED]`/`[LIKELY]`/`[UNCERTAIN]`/`[DEFER]`), actionability.
 
-### Critical failure conditions (Test 1 automatic fail)
+### v1 Eval (6 candidates, human scoring /90)
 
-- Calls Perplexity's live-cited data "fabricated"
-- Refuses to incorporate post-cutoff data when Perplexity has verified it
-- Presents a retired model's pricing as current without correction
+| Rank | Model | T1 | T2 | T3 | Total | Verdict |
+|------|-------|----|----|----|-------|---------|
+| 1 | Claude Opus 4.7 | 29 | 30 | 30 | 89/90 | PASS |
+| 2 | Qwen 2.5 72B | 26 | 28 | 28 | 82/90 | PASS |
+| 2T | Llama 3.3 70B | 26 | 28 | 28 | 82/90 | PASS |
+| 4 | GPT-4o | 25 | 27 | 28 | 80/90 | PASS |
+| 5 | Gemini 2.5 Pro | 26 | 24 | 28 | 78/90 | TRUNCATED |
+| 6 | DeepSeek V3 | 23 | 28 | 9 | 60/90 | FAIL |
+
+### v2 Eval (5 candidates, automated scoring with cost)
+
+Sonnet 4.6 and Haiku 4.5 added. Quick tier removed — Smart/Deep only.
+Automated scoring: 12 programmatic assertions (structural, attribution, tag presence).
+
+| Model | Auto Score | Cost/session | 1K sessions |
+|-------|------------|--------------|-------------|
+| Claude Haiku 4.5 | 83.3% | $0.00558 | $5.58 |
+| GPT-4o | 83.3% | $0.00730 | $7.30 |
+| Qwen 2.5 72B | 83.3% | $0.00131 | $1.31 |
+| Claude Opus 4.7 | 75.0% | $0.04357 | $43.57 |
+| Claude Sonnet 4.6 | 75.0% | $0.02343 | $23.43 |
+
+The auto/human scoring inversion (Haiku 83% auto vs Opus 89/90 human) reflects
+what automated checks cannot capture: analytical depth, narrative structure, and
+the quality of uncertainty attribution. Auto scoring measures structure;
+human scoring measures substance.
 
 ## Decision
 
-**Claude Opus 4.7 is the production synthesizer for the Deep and Smart tiers.**
+**Two-model synthesis routing based on query type.**
 
-After the `SYNTHESIS_TRUST_HIERARCHY` and `_SYNTHESIS_TASK_TEMPLATE` were
-updated in `backend/router.py` (ADR companion to `fix/synthesis-trust-
-hierarchy-perplexity-wins`), Claude's "PERPLEXITY WINS" compliance improved
-significantly. The combination of highest quality score, explicit contradiction
-resolution, and full confidence-tag adoption makes it the clear choice for
-sessions where synthesis quality is the primary variable.
+**Analytical queries** (RLHF, architecture, domain knowledge, expert opinion):
+→ Claude Opus 4.7 (`SYNTHESIS_ANALYTICAL`)
 
-**Tier routing** reduces cost substantially while maintaining quality where it
-matters:
+Claude leads on analytical depth (30/30 on T2 and T3), attribution quality,
+confidence tag adoption, and narrative coherence. No other candidate matched
+this across all three test dimensions.
 
-| Tier | Synthesizer | When used |
-|------|-------------|-----------|
-| Quick | Claude Haiku 4.5 | Factual lookups, brainstorms, gut checks |
-| Smart | Claude Sonnet 4.6 | Analysis, evaluations, plans (default) |
-| Deep | Claude Opus 4.7 | Architecture decisions, critical reports, strategic plans |
+**Post-cutoff factual queries** (pricing, model releases, deprecations, current
+events where Perplexity contradicts round-1):
+→ GPT-5.4 (`SYNTHESIS_FACTUAL`)
 
-## Cost Analysis
+Claude's trained refusal behavior fires on post-cutoff data regardless of system
+prompt instructions — confirmed across 8 sessions and 4 prompt variants.
+GPT-5.4 incorporates Perplexity grounded data without trained refusal.
 
-Cost rates per 1M tokens (as of April 2026):
+**Routing logic** (`perplexity_contradicts_round1()` in `backend/router.py`):
+If the Perplexity audit contains signals such as "retired", "deprecated",
+"incorrect", "as of 2026", "current pricing", or direct contradiction markers,
+route to `SYNTHESIS_FACTUAL`. Otherwise route to `SYNTHESIS_ANALYTICAL`.
 
-| Model | Input | Output | $/session (est.) | $/1K sessions |
-|-------|-------|--------|-----------------|--------------|
-| Claude Opus 4.7 | $5.00 | $25.00 | see eval results | — |
-| Claude Sonnet 4.6 | $3.00 | $15.00 | see eval results | — |
-| Claude Haiku 4.5 | $0.80 | $4.00 | see eval results | — |
-| GPT-4o | $2.50 | $10.00 | see eval results | — |
-| Qwen 2.5 72B | $0.40 | $1.20 | see eval results | — |
+**Fallback** (any synthesis failure):
+→ Qwen 2.5 72B (`SYNTHESIS_FALLBACK`)
 
-_Fill in from `experiments/synthesizer_eval/results/cost_data-*.json` after
-running the v2 eval harness:_
-```
-python -m experiments.synthesizer_eval.run_eval
-```
-
-**Tier-routing scenario (60% Quick / 30% Smart / 10% Deep):**
-Blended cost is significantly lower than all-Opus. See summary in
-`experiments/synthesizer_eval/results/summary-*.md`.
-
-## Alternatives Considered
-
-**GPT-4o** — scored 80/90 in v1. Solid on factual grounding but less
-consistent tag discipline. No architectural reason to prefer it over Claude
-when Claude's trust-hierarchy compliance has been corrected. Retained as a
-cross-provider check in the eval harness.
-
-**Qwen 2.5 72B (OpenRouter)** — scored 82/90 in v1 at a fraction of Opus
-cost. A viable cost-tier option if quality-per-dollar becomes the primary
-driver. Excluded from production for now because the eval harness cannot
-guarantee OpenRouter uptime or rate-limit behavior at scale.
-
-**Gemini 2.5 Pro** — scored 78/90 in v1 with truncation on Test 2. Excluded.
-Gemini is already a round-1 research seat; using it as the synthesizer
-introduces synthesis bias toward its own prior response.
-
-**DeepSeek V3** — critical failure on Test 3 (output corrupted). Excluded.
+Scored 82/90 human, 83.3% automated, $1.31/1K sessions. Viable open-weight
+fallback on a different provider with no shared failure mode with the primary chain.
 
 ## Consequences
 
-- Claude Opus 4.7 synthesizer must receive the updated `SYNTHESIS_TRUST_
-  HIERARCHY` block (three-tier hierarchy, "PERPLEXITY WINS", mandatory
-  contradiction scan). Any synthesizer regression is visible in Test 1 of the
-  eval harness.
-- Tier routing must be configurable per session — intake assigns the tier,
-  `backend/router.py` selects the synthesis model.
-- The eval harness (`experiments/synthesizer_eval/`) is a regression guard.
-  Run it when changing synthesis system prompts or switching models.
-- Cost analysis is automated via `experiments/generate_cost_report.py`.
+- Synthesis routing adds one classification step per session — negligible latency
+- Claude Opus 4.7 handles the majority of sessions; GPT-5.4 handles the specific
+  failure class where Claude's training data refusal would otherwise surface
+- `PipelineHealth` tracks which model handled synthesis and the routing reason,
+  surfaced as read-only annotations in the frontend after synthesis completes
+- DeepSeek V3 excluded — pivoted to Chinese-language RAM content mid-synthesis on
+  T3 (domain-technical prompt); root cause unknown, excluded without further investigation
+- Gemini 2.5 Pro excluded — T2 output truncated, context limit suspected; also
+  introduces synthesis bias since Gemini already holds a round-1 research seat
+- Llama 3.3 70B not included in production chain — performance tied Qwen at 82/90
+  but Qwen was selected as fallback for broader language coverage and consistent
+  OpenRouter availability
+- The eval harness (`experiments/synthesizer_eval/`) is the regression guard —
+  run it when changing synthesis system prompts or switching models
+
+## Alternatives Considered
+
+**Single synthesizer (Claude only):** Rejected. Claude's trained refusal on
+post-cutoff data is a structural limitation that prompt engineering cannot override.
+Confirmed empirically across 8 sessions and 4 prompt variants — the refusal is not
+a prompt problem, it is a training problem.
+
+**Single synthesizer (GPT-5.4):** Rejected. GPT-4o scored 80/90 human vs Claude's
+89/90. The analytical quality gap is real and user-visible on complex domain
+questions. Optimal synthesis on the majority case should not be sacrificed to handle
+the edge case.
+
+**Perplexity as synthesizer:** Deferred. Search-native design may produce
+citation-heavy but narratively weak synthesis. Not tested in this eval — worth
+revisiting if routing complexity becomes a maintenance burden.
+
+**Tier-specific synthesizer (Haiku for Smart, Opus for Deep):** Rejected. Cost
+optimization at the synthesis layer is premature — synthesis is called once per
+session and is not the dominant cost driver. Haiku's 83.3% automated score
+conceals structural deficiencies that human scoring would likely catch at T2 depth.
+
+## Evidence
+
+Transcripts in `docs/transcripts/` document synthesis behavior across 15 real
+sessions including failure cases (sessions 007, 008, 013) and successful cases
+(003, 005, 006, 009, 010, 011, 012). Session 013 is the index case for Claude's
+post-cutoff refusal on live Perplexity pricing data.

--- a/docs/decisions/003-intake-model-selection.md
+++ b/docs/decisions/003-intake-model-selection.md
@@ -1,129 +1,132 @@
 # ADR 003: Intake Model Selection
 
-**Status:** Accepted
+**Status:** Accepted  
 **Date:** 2026-04-17
 
 ## Context
 
-The intake model is the first AI the user interacts with. It runs before any
-frontier model is invoked and makes three decisions that gate session quality:
+ai-roundtable uses an intake stage to:
 
-1. **Clarification** — does the user's prompt have enough context to run the
-   roundtable, or does it need a single focused follow-up question?
-2. **Tier assignment** — should the session use Quick / Smart / Deep models?
-3. **Prompt optimization** — rewrite the user's raw input as a precise,
-   context-rich prompt that eliminates assumptions before passing to round-1.
+1. Detect whether a prompt needs clarification before the roundtable runs
+2. Preserve user-provided proper nouns exactly as typed
+3. Optimize the prompt for multi-model research
+4. Assign session tier (always "smart" — deep is user opt-in via the frontend modal)
 
-The intake model must also follow a **proper noun preservation rule**: any
-model name, product name, version number, or named entity provided by the user
-must survive into the optimized prompt unchanged. A model that substitutes
-"Claude Opus 4.7" with "Claude 3 Opus" (its training-data equivalent) corrupts
-the session before the first frontier model is called.
+The original intake model was Claude (via `IntakeSession`). This was replaced
+during development due to over-engineering for a classification task and cost.
+Gemini 2.5 Flash was the interim replacement. A discovered bug then forced a
+further change: intake was substituting user-provided model names with its own
+training-data alternatives, corrupting sessions before the first frontier model
+was called.
 
-Constraints specific to the intake role:
+An empirical evaluation harness was built and run against five candidates
+(see `experiments/intake_eval/`).
 
-- **Low latency** — intake runs synchronously before the roundtable. Every
-  millisecond here is felt by the user. Target < 2s.
-- **Structured output required** — must return a valid `IntakeDecision` JSON
-  object on every call. No graceful degradation to free text.
-- **Cost efficiency** — intake runs on every session, including Quick-tier
-  sessions that cost pennies end-to-end. High intake cost breaks the model.
-- **Reliability** — 503s or rate limits at intake abort the session before it
-  starts. Production must tolerate at least one retry.
+## The Proper Noun Bug
 
-## Evaluation
+During production use of Gemini 2.5 Flash as the interim intake model, the
+following was observed:
 
-The `experiments/intake_eval/` harness tests five candidates across six
-scenarios with automated assertion scoring.
+- User typed: "Compare Claude Opus 4.7 and GPT-5 for enterprise coding use cases"
+- Gemini Flash rewrote as: "Compare Claude 3 Opus and GPT-4 for enterprise coding use cases"
 
-### Candidates
+The entire research session ran against models the user did not ask about.
+Root cause: Gemini Flash's training data treats "Claude Opus 4.7" and "GPT-5"
+as unannounced future models and substitutes the nearest known alternatives.
+The `PROPER NOUN PRESERVATION` rule in the system prompt was insufficient —
+training data overrode the instruction at the point of token generation.
 
-| Candidate | Provider | Input rate | Output rate |
-|-----------|----------|-----------|------------|
-| Gemini 2.5 Flash | Google | $0.15/MTok | $0.60/MTok |
-| Gemini 2.0 Flash | Google | $0.10/MTok | $0.40/MTok |
-| GPT-4o Mini | OpenAI | $0.15/MTok | $0.60/MTok |
-| Claude Haiku 4.5 | Anthropic | $0.80/MTok | $4.00/MTok |
-| Qwen 2.5 72B | OpenRouter | $0.40/MTok | $1.20/MTok |
+This was confirmed in production transcript 013 and became the hard gate
+criterion for the intake eval.
 
-### Test Coverage
+## Evaluation Results
+
+Six tests with automated assertion scoring (see `experiments/intake_eval/results/`):
 
 | Test | Capability |
 |------|-----------|
-| test1-simple | Proceeds without clarification; smart tier |
-| test2-vague | Triggers exactly one clarifying question |
-| test3-proper-nouns | User-provided model names survive unchanged |
-| test4a-tier-quick | Factual lookup → quick tier |
-| test4b-tier-deep | Architecture decision → deep tier |
-| test5-two-turn | Proper nouns survive across clarification round-trip |
-| test6-consistency | Same borderline prompt → same tier across 3 runs |
+| T1 — Simple | Proceeds without clarification; assigns smart tier |
+| T2 — Vague | Triggers exactly one clarifying question |
+| T3 — Proper nouns | User-provided model names survive into optimized_prompt unchanged |
+| T4a — Tier quick | Factual lookup → quick tier |
+| T4b — Tier deep | Architecture decision → deep tier |
+| T5 — Two-turn | Proper nouns survive across clarification round-trip |
+| T6 — Consistency | Same borderline prompt → same tier across 3 runs |
 
-### Critical Failure Conditions
+| Model | Score | Cost/session | 1K sessions | Verdict |
+|-------|-------|--------------|-------------|---------|
+| GPT-4o Mini | 16/16 (100%) | $0.000226 | $0.23 | ✅ PASS |
+| Qwen 2.5 72B | 16/16 (100%) | $0.000583 | $0.58 | ✅ PASS |
+| Claude Haiku 4.5 | 10/16 (62%) | $0.002094 | $2.09 | ⚠️ PARTIAL |
+| Gemini 2.5 Flash | 4/14 (29%) | $0.000159 | $0.16 | ❌ FAIL |
+| Gemini 2.0 Flash | 0/14 (0%) | $0.000000 | $0.00 | ❌ API ERROR |
 
-- Any proper noun substitution in `optimized_prompt` → hard fail
-- JSON parse error on any test → hard fail for that test
-- Tier instability across consistency runs → hard fail
+Gemini 2.5 Flash returned `None` on T1, T3, T5, T6 — JSON parse failures
+(structured output not enforced). It passed only T2 and T4a. Its 29% score
+is not a marginal miss; it failed the proper noun test that motivated the eval.
+Gemini 2.0 Flash had a complete API failure.
 
-_Fill in results from `experiments/intake_eval/results/summary-*.md` after
-running the eval harness:_
-```
-python -m experiments.intake_eval.run_eval
-```
+GPT-4o Mini and Qwen 2.5 72B both scored 16/16. The consistency test showed
+GPT-4o Mini assigns `"smart"` stably across 3 runs; Claude Haiku assigned `"deep"`
+stably — an overcall for the borderline prompt used.
 
 ## Decision
 
-**Gemini 2.5 Flash is the production intake model.**
+**Intake fallback chain with provider diversity:**
 
-Key reasons:
+```
+Primary:   GPT-4o Mini      (OpenAI)
+Fallback1: Qwen 2.5 72B     (OpenRouter — different provider)
+Fallback2: Claude Haiku 4.5 (Anthropic — last resort)
+Emergency: Passthrough       (raw prompt, smart tier, never fails the user)
+```
 
-1. **Native structured output** — the Google Generative AI SDK's
-   `response_schema` parameter enforces the `IntakeDecision` Pydantic schema
-   at the API level. Parse errors are structurally impossible; no JSON
-   extraction logic is needed.
-2. **Low latency** — Gemini Flash is optimized for fast single-turn calls.
-   Typical intake call completes in < 1.5s.
-3. **Low cost** — at $0.15/$0.60 per MTok, intake cost is negligible relative
-   to round-1 and synthesis calls on Smart and Deep tiers. On Quick tier,
-   intake cost is within the same order of magnitude as synthesis.
-4. **Proper noun preservation** — with the `PROPER NOUN PRESERVATION` rule
-   added to `GEMINI_INTAKE_SYSTEM` and the preservation instruction in the
-   Turn 1 combined prompt, Gemini 2.5 Flash passes the preservation assertions.
+**Why GPT-4o Mini as primary:** 100% assertion score, stable `"smart"` tier
+assignment, passes proper noun preservation, $0.23/1K sessions. Uses
+`response_format: json_object` with `temperature: 0.1` for reliable structured
+output. No observed training-data substitution of user-provided model names.
 
-The intake model is intentionally pinned separately from round-1 Gemini via
-`INTAKE_MODEL = os.getenv("GEMINI_INTAKE_MODEL", "gemini-2.5-flash")` in
-`backend/models/google_client.py`. This allows the intake model to be upgraded
-or swapped without touching the research model configuration.
+**Why Qwen 2.5 72B as Fallback1:** Also 100% — identical quality to primary,
+on OpenRouter (different provider), $0.58/1K. If OpenAI is down, Qwen has no
+shared failure mode.
 
-## Alternatives Considered
+**Why Claude Haiku as Fallback2:** 62% score — lower than primary candidates
+but acceptable as last resort. Third distinct provider. Higher cost ($2.09/1K)
+is only incurred during OpenAI+OpenRouter simultaneous failure.
 
-**Claude Haiku 4.5** — produces good intake quality but costs 5–6x more per
-call than Gemini Flash at intake token volumes. Lacks native structured output
-enforcement; requires JSON extraction. Excluded for cost.
+**Why passthrough emergency exists:** Intake failure should never block a session.
+The passthrough returns the raw user prompt at smart tier — research quality
+degrades but the session runs.
 
-**GPT-4o Mini** — viable quality, comparable cost to Gemini Flash. Lacks
-`response_schema` enforcement; uses `response_format: {"type": "json_object"}`
-which reduces but does not eliminate parse errors. Acceptable as fallback.
-
-**Gemini 2.0 Flash** — previous generation. Marginally cheaper than 2.5 Flash
-but lower quality on complex clarification decisions. Only relevant if 2.5
-Flash becomes unavailable.
-
-**Qwen 2.5 72B (OpenRouter)** — open-weight model with lower cost than Haiku
-but higher than Gemini Flash. No structured output enforcement. OpenRouter
-latency is less predictable for synchronous intake use. Excluded.
+**Intake always returns `tier: "smart"`:** Deep sessions require explicit user
+confirmation via the frontend modal. `IntakeDecision.tier` is `Literal["smart"]`
+in `backend/models/intake_decision.py` — schema enforces this at the type level,
+not just the prompt level. The eval was run before this simplification (T4a/T4b
+tested quick and deep tier assignment); those tests are now superseded.
 
 ## Consequences
 
-- `GEMINI_INTAKE_MODEL` env var allows intake model override without a
-  code deploy. Can switch to Gemini 2.0 Flash or GPT-4o Mini as fallback.
-- The `PROPER NOUN PRESERVATION` rule must be maintained in `GEMINI_INTAKE_SYSTEM`
-  for all future iterations of the system prompt.
-- The two-turn flow (Turn 0 → clarifying question → Turn 1 → optimized prompt)
-  must preserve proper nouns across both turns. The Turn 1 combined string must
-  include the preservation instruction (verified in test5-two-turn).
-- Gemini 503 errors during intake abort the session. `backend/models/
-  google_client.py` implements retry logic (`call_gemini_intake` retries up
-  to 3 times with 2s backoff on 503).
-- The eval harness (`experiments/intake_eval/`) is a regression guard. Run it
-  when changing `GEMINI_INTAKE_SYSTEM` or switching intake models.
-- Cost analysis is automated via `experiments/generate_cost_report.py`.
+- Intake cost: ~$0.23/1K sessions (negligible at any scale)
+- Provider diversity across the fallback chain — no single provider outage
+  can block intake
+- Passthrough emergency ensures sessions always run even if all intake models fail
+- `IntakeDecision.tier: Literal["smart"]` makes the two-tier architecture
+  enforceable at the type system level, not just by convention
+- The eval harness (`experiments/intake_eval/`) is the regression guard — run it
+  when changing `INTAKE_SYSTEM_PROMPT` or adding intake model candidates
+
+## Alternatives Considered
+
+**Gemini 2.5 Flash as primary:** Was the interim primary after Claude replacement.
+Rejected after eval — 29% score, failed proper noun preservation. The bug was
+confirmed in production transcript 013.
+
+**Claude Sonnet 4.6 as primary:** Considered for brand consistency. Rejected —
+GPT-4o Mini scored identically (100%) at 23× lower cost. Brand consistency at
+the intake layer is invisible to users; they see the optimized prompt, not which
+model processed their input.
+
+**End-to-end quality eval (intake prompt → research output quality):** Proposed
+but deferred to reduce complexity. The mechanical correctness eval (100% on
+GPT-4o Mini) is sufficient for the intake classification task. Measure intake
+quality by research output quality only if intake becomes a bottleneck.


### PR DESCRIPTION
## What
Evidence-based architecture decision records for synthesizer and
intake model selection.

## ADR 002 — Synthesizer
Dual-model routing: Claude Opus 4.7 (analytical) / GPT-5.4 (factual).
Documents Claude's post-cutoff refusal as a training constraint,
not a prompt engineering failure. Includes v1 human scores (89/90 Opus)
and v2 automated scores from eval harness.

## ADR 003 — Intake
GPT-4o Mini primary (100% eval score). Documents the proper noun
substitution bug that disqualified Gemini 2.5 Flash. IntakeDecision.tier
locked to Literal["smart"] — architecture enforced at schema level.