### PR TITLE
feat: UX overhaul — reversed pipeline, always-deep factcheck, intake tier assignment

### DIFF
--- a/backend/models/intake_decision.py
+++ b/backend/models/intake_decision.py
@@ -14,7 +14,7 @@ class IntakeDecision(BaseModel):
     needs_clarification: bool
     clarifying_question: Optional[str] = None  # only when needs_clarification is True
     optimized_prompt: str        # refined, context-enriched version of user's raw prompt
-    tier: Literal["smart"]   # intake always returns smart; frontend may upgrade to deep
+    tier: Literal["smart", "deep"]  # intake assigns based on prompt complexity
     output_type: str             # e.g. "report", "plan", "decision", "brainstorm", "analysis"
     reasoning: str               # one sentence shown in UI:
                                  # "Deep selected — architecture decision with significant tradeoffs"

--- a/backend/models/model_config.py
+++ b/backend/models/model_config.py
@@ -18,7 +18,7 @@ Deep tier uses top models throughout:
     No executor/advisor split — single high-quality pass.
 
 Grok participates in both Smart and Deep.
-Deep sessions are never auto-assigned by intake — user opt-in only.
+Deep sessions are assigned by intake for high-stakes questions, or upgraded by user.
 
 Factcheck always uses deep audit depth (~2000 tokens output).
 The Smart/Deep audit prompt distinction is preserved in perplexity_client.py
@@ -140,8 +140,10 @@ SYNTHESIS_FACTUAL    = os.getenv("SYNTHESIS_FACTUAL",    "gpt-5.4")
 SYNTHESIS_FALLBACK   = os.getenv("SYNTHESIS_FALLBACK",   "qwen/qwen-2.5-72b-instruct")
 
 # ── Intake ────────────────────────────────────────────────────────────────────
-# Intake always assigns "smart" tier — never "deep".
-# Deep requires explicit user opt-in via the session UI.
+# Intake assigns "smart" or "deep" based on prompt complexity.
+# Deep is assigned for architecture decisions, build/buy, strategic choices,
+# and high-stakes questions. Smart is the default for most sessions.
+# If intake assigns deep, deep runs — user cannot downgrade. See ADR 003 addendum.
 #
 # Fallback chain uses provider diversity:
 #   Primary:   GPT-4o Mini  (OpenAI — 16/16 eval, $0.23/1K sessions)

--- a/backend/models/model_config.py
+++ b/backend/models/model_config.py
@@ -20,10 +20,10 @@ Deep tier uses top models throughout:
 Grok participates in both Smart and Deep.
 Deep sessions are never auto-assigned by intake — user opt-in only.
 
-Factcheck has Smart and Deep audit depths:
-    Smart: targeted, signal-focused, fast (~800 tokens output)
-    Deep:  comprehensive, adversarial, thorough (~2000 tokens output)
-    Both use Perplexity as primary — same model, different prompt depth.
+Factcheck always uses deep audit depth (~2000 tokens output).
+The Smart/Deep audit prompt distinction is preserved in perplexity_client.py
+for future flexibility, but get_factcheck_max_tokens() always returns
+FACTCHECK_DEEP_MAX_TOKENS. See ADR 004 addendum.
 """
 
 import os
@@ -231,7 +231,16 @@ def get_all_labs() -> list:
 
 
 def get_factcheck_max_tokens(tier: str) -> int:
-    """Return max output tokens for factcheck audit by tier."""
-    if tier == "deep":
-        return FACTCHECK_DEEP_MAX_TOKENS
-    return FACTCHECK_SMART_MAX_TOKENS
+    """
+    Always use deep audit depth regardless of session tier.
+
+    Rationale: fact-check is the grounding layer for synthesis.
+    Shallow fact-check produces shallow grounding regardless of
+    research tier. The cost difference (~$0.0008/session) is
+    negligible. Latency addition (~10-15s) is acceptable for a
+    tool positioned as serious deliberation.
+
+    The tier parameter is kept for future flexibility but is
+    intentionally ignored.
+    """
+    return FACTCHECK_DEEP_MAX_TOKENS  # always 2000 tokens

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -55,16 +55,18 @@ INTAKE_MODEL = INTAKE_PRIMARY
 
 def _build_intake_system_prompt() -> str:
     return """
-You are an intake analyst for an AI research roundtable designed for
-serious deliberation. Your job is to analyze the user's prompt and
-prepare it for a multi-model research session.
+You are an intake analyst for ai-roundtable — a serious deliberation
+tool that delivers the best answer possible using the best tools available.
+
+Your job is to analyze the user's prompt and prepare it for a
+multi-model research session.
 
 Return a JSON object with exactly these fields:
 {
   "needs_clarification": bool,
   "clarifying_question": string or null,
   "optimized_prompt": string,
-  "tier": "smart",
+  "tier": "smart" | "deep",
   "output_type": string,
   "reasoning": string
 }
@@ -72,26 +74,45 @@ Return a JSON object with exactly these fields:
 ## Rules
 
 1. needs_clarification: true ONLY if intent is genuinely ambiguous
-   or critical context is missing.
+   or critical context is missing that would change the research direction.
 
-2. clarifying_question: ONE focused question about intent or scope.
-   Null if needs_clarification is false.
+2. clarifying_question: ONE focused question. Null if not needed.
 
 3. PROPER NOUN PRESERVATION — CRITICAL:
-   Never substitute model names, product names, version numbers, or
-   any named entity the user provided. Use them exactly as written.
+   Never substitute model names, product names, version numbers, company
+   names, or any named entity the user provided. Use them exactly as written.
+   If the user writes "Claude Opus 4.7" do not change it to any other model.
 
-4. optimized_prompt: refined, context-enriched version preserving
-   ALL user-provided proper nouns exactly.
+4. optimized_prompt: refined, context-enriched version of the user's
+   prompt. Preserve ALL user-provided proper nouns exactly.
 
-5. tier: ALWAYS return "smart". Never return any other value.
-   Deep sessions are user-initiated — never assigned by intake.
+5. tier assignment — assign the tier the question deserves:
+
+   "smart": the default for most sessions.
+   - Analysis, recommendations, research, comparisons
+   - Technical evaluations and factual questions
+   - "What is...", "Compare X vs Y", "Explain how...", "What are the risks of..."
+   - Questions where getting it 80% right is sufficient
+
+   "deep": assign when the question involves high-stakes decisions
+   or complex multi-dimensional problems where getting it wrong has
+   real consequences.
+   - Architecture decisions: "Design the architecture for..."
+   - Build vs buy decisions: "Should we build or buy..."
+   - Strategic decisions: "What is our go-to-market strategy for..."
+   - Investment or hiring decisions
+   - Questions where getting it wrong has serious consequences
+
+   Be conservative — most questions are smart.
+   When in doubt, assign smart.
+
+   IMPORTANT: The user cannot downgrade a deep assignment. If you
+   assign deep, deep runs. Assign deep only when genuinely warranted.
 
 6. output_type: e.g. "analysis", "comparison", "report", "plan",
-   "decision", "brainstorm", "factual answer"
+   "decision", "research", "factual answer"
 
-7. reasoning: one sentence explaining the optimized prompt direction.
-   Do NOT mention tier in the reasoning — it is always smart.
+7. reasoning: one sentence explaining tier assignment and prompt direction.
 
 Return valid JSON only. No prose outside the JSON object.
 """

--- a/docs/decisions/003-intake-model-selection.md
+++ b/docs/decisions/003-intake-model-selection.md
@@ -130,3 +130,34 @@ model processed their input.
 but deferred to reduce complexity. The mechanical correctness eval (100% on
 GPT-4o Mini) is sufficient for the intake classification task. Measure intake
 quality by research output quality only if intake becomes a bottleneck.
+
+---
+
+## Addendum — April 19, 2026: Intake Now Assigns Deep When Warranted
+
+**Decision:** Intake assigns either "smart" or "deep" tier based on
+prompt complexity. The previous lock to `Literal["smart"]` is reversed.
+
+**Rationale:**
+The product tagline "The best answer possible, with the best tools
+available" requires the tool to select the appropriate research depth
+automatically. Asking users to choose Smart vs Deep is a compromise —
+most users cannot accurately assess whether their question needs deep
+thinking.
+
+**Tier assignment criteria:**
+- Smart: analysis, research, comparisons, factual questions (default)
+- Deep: architecture decisions, build/buy decisions, strategic choices,
+  high-stakes questions where getting it wrong has real consequences
+
+**No downgrade rule:**
+If intake assigns Deep, Deep runs. No user override. No downgrade path.
+If the user believes intake misclassified their question, they rephrase
+and resubmit — intake re-runs with the rephrased prompt.
+
+If intake assigns Smart, the user can upgrade to Deep via the slider.
+The upgrade is one-directional — once Deep is selected, no downgrade.
+
+**Schema change:**
+`IntakeDecision.tier: Literal["smart", "deep"]` (restored from
+the temporary `Literal["smart"]` lock introduced in the resilience PR).

--- a/docs/decisions/004-factcheck-model-selection.md
+++ b/docs/decisions/004-factcheck-model-selection.md
@@ -168,6 +168,25 @@ FACTCHECK_FALLBACK2 = os.getenv("FACTCHECK_FALLBACK2", "gpt-5.4")
 
 ---
 
+## Addendum — April 19, 2026: Always Deep Fact-Check
+
+**Decision:** Fact-check audit depth is always Deep (2000 tokens)
+regardless of session tier (Smart or Deep).
+
+**Rationale:**
+- Fact-check is the grounding layer for synthesis. Shallow grounding
+  produces lower quality synthesis regardless of research tier depth.
+- Cost difference: ~$0.0008/session — negligible at any usage scale.
+- Latency addition: ~10-15 seconds — acceptable for a deliberation tool.
+- The Smart/Deep audit prompt distinction is preserved in code for
+  future flexibility, but `get_factcheck_max_tokens()` always returns
+  `FACTCHECK_DEEP_MAX_TOKENS` (2000).
+
+This decision aligns with the product tagline:
+"The best answer possible, with the best tools available."
+
+---
+
 ## Follow-up Items
 
 1. **Fix T1 scorer:** Change `must_mention: ["retired"]` to

--- a/frontend/src/components/IntakeFlow.jsx
+++ b/frontend/src/components/IntakeFlow.jsx
@@ -1,14 +1,21 @@
 /**
  * frontend/src/components/IntakeFlow.jsx
  *
- * Screen 2 — Gemini Flash intake (two-turn max).
+ * Screen 2 — Intake analysis (two-turn max).
  *
  * Flow:
  *   1. Mount with initialUserMessage → POST /api/intake/start
  *   2a. status "clarifying" → show inline clarifying question
  *       User answers → POST /api/intake/respond → status "complete"
  *   2b. status "complete" → show tier badge + reasoning
- *   3. User confirms tier (or overrides) → onComplete(config)
+ *   3. User confirms tier → onComplete(config)
+ *
+ * Tier logic:
+ *   - Intake assigns "smart" or "deep" based on prompt complexity.
+ *   - If intake assigns deep: no slider, badge shows "🔭 Deep · Auto-selected",
+ *     user cannot downgrade.
+ *   - If intake assigns smart: pill slider shown, user can upgrade to deep
+ *     (one-directional — once deep is selected, no return to smart).
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -20,47 +27,6 @@ const TIER_LABELS = {
   smart: "⚖ Smart",
   deep:  "🔍 Deep",
 };
-
-/**
- * Modal confirming the user understands the cost/time trade-off of upgrading to Deep.
- */
-function DeepConfirmationModal({ onConfirm, onCancel }) {
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="deep-modal-title"
-    >
-      <div className="w-full max-w-sm rounded-xl border border-[#2a2a2a] bg-[#1e1e1e] p-6 shadow-xl">
-        <h2 id="deep-modal-title" className="mb-2 text-base font-semibold text-[#e8e8e8]">
-          Upgrade to Deep?
-        </h2>
-        <p className="mb-5 text-sm leading-relaxed text-[#888888]">
-          Sessions take longer (10–20 min) and cost significantly more.
-          Deep uses flagship models throughout — best for reports and critical decisions.
-        </p>
-        <div className="flex gap-3 justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-lg border border-[#2a2a2a] bg-[#0d0d0d] px-4 py-2 text-sm text-[#888888] hover:text-[#e8e8e8] focus:outline-none"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            className="rounded-lg px-4 py-2 text-sm font-bold focus:outline-none"
-            style={{ background: "#F5A623", color: "#0d0d0d" }}
-          >
-            Upgrade to Deep
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 /**
  * @param {Object}   props
@@ -76,9 +42,12 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
   const [answer, setAnswer] = useState("");
   const [submittingAnswer, setSubmittingAnswer] = useState(false);
   const [config, setConfig] = useState(null);
-  /** Whether the Deep upgrade confirmation modal is open */
-  const [showDeepConfirm, setShowDeepConfirm] = useState(false);
+  /** Tier assigned by intake — "smart" | "deep". Immutable after set. */
+  const [intakeTier, setIntakeTier] = useState("smart");
+  /** User's current tier selection — starts at intakeTier, can only move to "deep". */
   const [tierChoice, setTierChoice] = useState("smart");
+  /** Once deep is selected (by intake or user), this locks — no return to smart. */
+  const [tierLocked, setTierLocked] = useState(false);
   const [error, setError] = useState(null);
   const answerRef = useRef(null);
   const hasFiredRef = useRef(false);
@@ -112,8 +81,11 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
           setPhase("clarifying");
         } else {
           const cfg = data.config || {};
+          const tier = cfg.tier || "smart";
           setConfig(cfg);
-          setTierChoice(cfg.tier || "smart");
+          setIntakeTier(tier);
+          setTierChoice(tier);
+          setTierLocked(tier === "deep");
           setPhase("badge");
         }
       } catch (e) {
@@ -141,8 +113,11 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
       }
       const data = await res.json();
       const cfg = data.config || {};
+      const tier = cfg.tier || "smart";
       setConfig(cfg);
-      setTierChoice(cfg.tier || "smart");
+      setIntakeTier(tier);
+      setTierChoice(tier);
+      setTierLocked(tier === "deep");
       setPhase("badge");
     } catch (e) {
       setError(e.message || "Submit failed");
@@ -150,6 +125,13 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
       setSubmittingAnswer(false);
     }
   }, [answer, sessionId, submittingAnswer]);
+
+  const handleSliderChange = useCallback(() => {
+    // Only allow smart → deep. Deep → smart is never permitted.
+    if (tierLocked) return;
+    setTierChoice("deep");
+    setTierLocked(true);
+  }, [tierLocked]);
 
   const handleConfirm = useCallback(() => {
     if (!config || typeof onComplete !== "function") return;
@@ -236,41 +218,88 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
               </div>
             </div>
 
-            {/* Tier badge */}
-            <div className="flex items-start justify-between gap-3 rounded-lg border border-[#2a2a2a] bg-[#1e1e1e] px-4 py-3">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span
-                    className="inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold"
-                    style={{ background: "#F5A623", color: "#0d0d0d" }}
-                  >
-                    {TIER_LABELS[tierChoice] || tierChoice}
-                  </span>
-                  <span className="text-sm font-medium text-[#e8e8e8]">
-                    {config.output_type
-                      ? config.output_type.charAt(0).toUpperCase() + config.output_type.slice(1)
-                      : ""}
-                  </span>
-                </div>
-                <p className="mt-1.5 text-sm text-[#888888]">{config.reasoning}</p>
-              </div>
-              {tierChoice === "smart" && (
-                <button
-                  type="button"
-                  onClick={() => setShowDeepConfirm(true)}
-                  className="shrink-0 text-sm text-[#F5A623] underline-offset-2 hover:opacity-80 focus:outline-none"
+            {/* Tier badge — always reflects current tierChoice */}
+            <div className="rounded-lg border border-[#2a2a2a] bg-[#1e1e1e] px-4 py-3">
+              <div className="flex items-center gap-2">
+                <span
+                  className="inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold"
+                  style={{ background: "#F5A623", color: "#0d0d0d" }}
                 >
-                  Upgrade to Deep ↑
-                </button>
-              )}
+                  {TIER_LABELS[tierChoice] || tierChoice}
+                </span>
+                <span className="text-sm font-medium text-[#e8e8e8]">
+                  {config.output_type
+                    ? config.output_type.charAt(0).toUpperCase() + config.output_type.slice(1)
+                    : ""}
+                </span>
+              </div>
+              <p className="mt-1.5 text-sm text-[#888888]">{config.reasoning}</p>
             </div>
 
-            {/* Deep upgrade confirmation modal */}
-            {showDeepConfirm && (
-              <DeepConfirmationModal
-                onConfirm={() => { setTierChoice("deep"); setShowDeepConfirm(false); }}
-                onCancel={() => setShowDeepConfirm(false)}
-              />
+            {/* RESEARCH DEPTH — slider when smart, static notice when deep-locked by intake */}
+            {intakeTier === "deep" ? (
+              /* Deep assigned by intake — no controls, no appeal */
+              <div className="rounded-lg border border-[#2a2a2a] bg-[#1e1e1e] px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold" style={{ color: "#F5A623" }}>
+                    🔭 Deep · Auto-selected
+                  </span>
+                </div>
+                <p className="mt-1.5 text-sm text-[#888888]">
+                  This question warrants deep analysis — top models with extended thinking.
+                </p>
+              </div>
+            ) : (
+              /* Smart assigned by intake — slider, user may upgrade to deep (one-way) */
+              <div>
+                <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[#888888]">Research Depth</p>
+                <div className="flex items-center gap-4">
+                  {/* Smart label */}
+                  <span
+                    className="text-sm font-medium transition-colors duration-200"
+                    style={{ color: tierChoice === "smart" ? "#e8e8e8" : "#555555" }}
+                  >
+                    Smart
+                  </span>
+
+                  {/* Pill toggle track */}
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={tierChoice === "deep"}
+                    aria-label="Research depth — slide right to upgrade to Deep"
+                    onClick={handleSliderChange}
+                    disabled={tierLocked}
+                    className="relative h-7 w-14 flex-shrink-0 rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623] disabled:cursor-not-allowed"
+                    style={{ background: tierChoice === "deep" ? "#F5A623" : "#2a2a2a" }}
+                  >
+                    <span
+                      className="absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-[#e8e8e8] shadow transition-transform duration-200"
+                      style={{ transform: tierChoice === "deep" ? "translateX(28px)" : "translateX(0)" }}
+                    />
+                  </button>
+
+                  {/* Deep label */}
+                  <span
+                    className="text-sm font-medium transition-colors duration-200"
+                    style={{ color: tierChoice === "deep" ? "#e8e8e8" : "#555555" }}
+                  >
+                    Deep
+                  </span>
+                </div>
+
+                {/* Description — changes on toggle, locked notice when deep selected */}
+                <p className="mt-2 text-sm text-[#888888]">
+                  {tierChoice === "smart"
+                    ? "Executor + advisor per model · recommended for most sessions"
+                    : "Top models · extended thinking · for high-stakes decisions"}
+                </p>
+                {tierLocked && tierChoice === "deep" && (
+                  <p className="mt-1 text-xs text-[#555555]">
+                    Deep selected — session will run at full depth.
+                  </p>
+                )}
+              </div>
             )}
 
             {/* Confirm */}

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -47,6 +47,40 @@ function wsUrlFromApiBase() {
 
 /** @typedef {'idle' | 'round1_parallel' | 'perplexity' | 'synthesis'} StreamPhase */
 
+/**
+ * Collapsible stage header — active stages show plain label, done stages show toggle.
+ */
+function StageHeader({ label, summary, done, open, onToggle, active }) {
+  if (!done) {
+    return (
+      <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary ${active ? "animate-pulse" : ""}`}>
+        {label}
+      </h2>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full items-center gap-2 text-left focus:outline-none"
+      aria-expanded={open}
+    >
+      <span
+        aria-hidden
+        className="shrink-0 text-[10px] text-text-secondary"
+        style={{ display: "inline-block", transform: open ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}
+      >
+        ▾
+      </span>
+      <span className="text-xs font-semibold uppercase tracking-wide text-text-secondary">{label}</span>
+      {!open && summary && (
+        <span className="ml-1 text-xs text-[#555555]">{summary}</span>
+      )}
+      <span className="ml-auto text-xs text-[#555555]" aria-hidden>✓</span>
+    </button>
+  );
+}
+
 function timestamp() {
   return new Date().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
@@ -262,9 +296,22 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
 
   const [leaveIntent, setLeaveIntent] = useState(null);
 
-  // ── Synthesis annotations — read-only, shown collapsed after synthesis ────
+  // ── Synthesis annotations — shown in Session notes panel ────────────────
   const [annotations, setAnnotations] = useState([]);
   const [annotationsOpen, setAnnotationsOpen] = useState(false);
+
+  // ── Pipeline stage collapse/expand state ──────────────────────────────────
+  // Stages auto-collapse when complete, synthesis auto-expands.
+  // After auto-transition, user can toggle freely.
+  const [researchOpen, setResearchOpen] = useState(true);
+  const [factcheckOpen, setFactcheckOpen] = useState(true);
+  const [synthesisOpen, setSynthesisOpen] = useState(false);
+  // Individual model sub-panel expand state inside RESEARCH (all open by default)
+  const [modelOpen, setModelOpen] = useState({ claude: true, gemini: true, gpt: true, grok: true });
+
+  const researchAutoCollapsedRef = useRef(false);
+  const factcheckAutoCollapsedRef = useRef(false);
+  const synthesisAutoExpandedRef = useRef(false);
 
   const r1CountsRef = useRef({ Gemini: 0, GPT: 0, Grok: 0, Claude: 0 });
 
@@ -401,6 +448,13 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(true);
     phaseRef.current = "idle";
     r1CountsRef.current = { Gemini: ge.length, GPT: gp.length, Grok: grk.length, Claude: cla.length };
+    // Resume: all stages complete — research/factcheck collapsed, synthesis expanded
+    setResearchOpen(false);
+    setFactcheckOpen(false);
+    setSynthesisOpen(true);
+    researchAutoCollapsedRef.current = true;
+    factcheckAutoCollapsedRef.current = true;
+    synthesisAutoExpandedRef.current = true;
   }, [resumeTranscript, sessionConfig]);
 
   useEffect(() => {
@@ -443,6 +497,13 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(false);
     setAnnotations([]);
     setAnnotationsOpen(false);
+    setResearchOpen(true);
+    setFactcheckOpen(true);
+    setSynthesisOpen(false);
+    setModelOpen({ claude: true, gemini: true, gpt: true, grok: true });
+    researchAutoCollapsedRef.current = false;
+    factcheckAutoCollapsedRef.current = false;
+    synthesisAutoExpandedRef.current = false;
 
     const url = wsUrlFromApiBase();
 
@@ -724,6 +785,36 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     return { promptDone, transcriptDone, transcriptActive, factDone, factActive, sDone, sActive, sLabel };
   }, [isResume, sessionStarted, synthesisPhaseEntered, perplexityPhase, synthesisThinking, synthesisStreaming, synthesisFinal]);
 
+  // ── Pipeline stage done flags ─────────────────────────────────────────────
+  const researchStageDone = isResume || perplexityPhase !== "off" || synthesisPhaseEntered;
+  const factcheckStageDone = isResume || perplexityPhase === "content" ||
+    (synthesisPhaseEntered && perplexityPhase !== "thinking");
+  const synthesisStageDone = isResume || synthesisFinal;
+
+  // Auto-collapse research when complete (fires once on transition)
+  useEffect(() => {
+    if (researchStageDone && !researchAutoCollapsedRef.current) {
+      researchAutoCollapsedRef.current = true;
+      setResearchOpen(false);
+    }
+  }, [researchStageDone]);
+
+  // Auto-collapse factcheck when complete (fires once on transition)
+  useEffect(() => {
+    if (factcheckStageDone && !factcheckAutoCollapsedRef.current) {
+      factcheckAutoCollapsedRef.current = true;
+      setFactcheckOpen(false);
+    }
+  }, [factcheckStageDone]);
+
+  // Auto-expand synthesis when complete (fires once on transition)
+  useEffect(() => {
+    if (synthesisStageDone && !synthesisAutoExpandedRef.current) {
+      synthesisAutoExpandedRef.current = true;
+      setSynthesisOpen(true);
+    }
+  }, [synthesisStageDone]);
+
   const showTranscriptRoundtable = isResume || sessionStarted;
 
   const showGeminiThinking =
@@ -812,12 +903,10 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             {"<"} {formatTierBadge(sessionConfig?.tier)} {">"}
           </span>
           <span className="mx-1.5" style={{ color: "#F5A623" }}>·</span>
-          {/* PROMPT */}
           <span style={{ color: breadcrumbState.promptDone ? "#F5A623" : "#666666" }}>
             {breadcrumbState.promptDone ? "✓" : "○"} PROMPT
           </span>
           <span className="mx-1" style={{ color: "#F5A623" }}>→</span>
-          {/* RESEARCH */}
           <span
             className={breadcrumbState.transcriptActive ? "animate-pulse" : ""}
             style={{ color: breadcrumbState.transcriptDone || breadcrumbState.transcriptActive ? "#F5A623" : "#666666" }}
@@ -825,7 +914,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             {breadcrumbState.transcriptDone ? "✓" : breadcrumbState.transcriptActive ? "●" : "○"} RESEARCH
           </span>
           <span className="mx-1" style={{ color: "#F5A623" }}>→</span>
-          {/* FACT-CHECK */}
           <span
             className={breadcrumbState.factActive ? "animate-pulse" : ""}
             style={{ color: breadcrumbState.factDone || breadcrumbState.factActive ? "#F5A623" : "#666666" }}
@@ -833,7 +921,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             {breadcrumbState.factDone ? "✓" : breadcrumbState.factActive ? "●" : "○"} FACT-CHECK
           </span>
           <span className="mx-1" style={{ color: "#F5A623" }}>→</span>
-          {/* SYNTHESIS */}
           <span
             className={breadcrumbState.sActive ? "animate-pulse" : ""}
             style={{ color: breadcrumbState.sDone || breadcrumbState.sActive ? "#F5A623" : "#666666" }}
@@ -843,13 +930,14 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
         </div>
       </Header>
 
-      <div className="mx-auto max-w-3xl space-y-6 px-4 py-6 sm:px-6">
+      <div className="mx-auto max-w-3xl space-y-4 px-4 py-6 sm:px-6">
         {configError && (
           <p className="text-sm text-red-400" role="alert">
             {configError}
           </p>
         )}
 
+        {/* ── PROMPT — fixed, always visible ── */}
         <section aria-label="Session prompt">
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
             Prompt
@@ -859,196 +947,274 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
           </div>
         </section>
 
-        <section aria-label="Model responses" className="space-y-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-text-secondary">
-            Research
-          </h2>
-
-          {showTranscriptRoundtable && (
-            <>
-              <div className={round1GridClass}>
-                {geminiRoundActive && (
-                  <div className="min-w-0 space-y-1">
-                    {showGeminiThinking ? (
-                      <ThinkingDotsBubble label="🔵 GEMINI" color={MODEL_HEX.Gemini} />
-                    ) : geminiR1Complete && isSkipNotice(geminiR1) ? (
-                      <p className="text-xs text-[#888888]" role="status">
-                        Gemini is unavailable right now — skipped this round.
-                      </p>
-                    ) : (
-                      <>
-                        <ModelBubble
-                          sender="Gemini"
-                          titleOverride="🔵 GEMINI"
-                          content={bubbleBody(geminiR1, geminiR1Complete)}
-                          isStreaming={geminiR1Streaming}
-                          round="round1"
-                          complete={geminiR1Complete}
-                        />
-                        {geminiAdvisorReviewing ? (
-                          <p className="text-xs text-[#888888]" role="status" aria-live="polite">
-                            ⚖ advisor reviewing...
-                          </p>
-                        ) : null}
-                      </>
+        {/* ── SYNTHESIS — shown when phase entered; sits immediately below PROMPT ── */}
+        {synthesisPhaseEntered && (
+          <section aria-label="Synthesis" className="space-y-3">
+            <StageHeader
+              label={breadcrumbState.sLabel}
+              summary={null}
+              done={synthesisStageDone}
+              open={synthesisOpen}
+              onToggle={() => setSynthesisOpen((o) => !o)}
+              active={!synthesisStageDone}
+            />
+            {/* Content: show when active OR when done+open */}
+            {(!synthesisStageDone || synthesisOpen) && (
+              <div className="space-y-4">
+                {synthesisThinking && !synthesisFinal && !String(synthesisText).trim() && (
+                  <ThinkingDotsBubble
+                    label="🟠 CLAUDE"
+                    color={MODEL_HEX.Claude}
+                    subtitle="Synthesizing your roundtable..."
+                  />
+                )}
+                {(synthesisStreaming || synthesisFinal || synthesisText.length > 0) && (
+                  <SynthesisPanel
+                    content={synthesisBody}
+                    isStreaming={synthesisStreaming && !synthesisFinal}
+                    complete={synthesisFinal}
+                  />
+                )}
+                {/* Session notes — only when there are noteworthy annotations */}
+                {sessionComplete && annotations.length > 0 && (
+                  <div className="rounded-lg border border-border bg-[#161616]" style={{ borderLeft: "3px solid #2a2a2a" }}>
+                    <button
+                      type="button"
+                      onClick={() => setAnnotationsOpen((o) => !o)}
+                      className="flex w-full items-center gap-2 px-4 py-3 text-left text-xs text-text-secondary transition-colors hover:text-text-primary focus:outline-none"
+                      aria-expanded={annotationsOpen}
+                    >
+                      <span aria-hidden style={{ display: "inline-block", transform: annotationsOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                      Session notes
+                    </button>
+                    {annotationsOpen && (
+                      <ul className="space-y-1.5 px-4 pb-4 pt-1">
+                        {annotations.map((a, i) => (
+                          <li key={i} className="flex gap-2 text-xs leading-relaxed text-text-secondary">
+                            <span className="shrink-0 text-[#444444]">·</span>
+                            <span>{a}</span>
+                          </li>
+                        ))}
+                      </ul>
                     )}
                   </div>
-                )}
-                {gptRoundActive && (
-                  <div className="min-w-0 space-y-1">
-                    {showGptThinking ? (
-                      <ThinkingDotsBubble label="🟢 GPT" color={MODEL_HEX.GPT} />
-                    ) : gptR1Complete && isSkipNotice(gptR1) ? (
-                      <p className="text-xs text-[#888888]" role="status">
-                        GPT is unavailable right now — skipped this round.
-                      </p>
-                    ) : (
-                      <>
-                        <ModelBubble
-                          sender="GPT"
-                          titleOverride="🟢 GPT"
-                          content={bubbleBody(gptR1, gptR1Complete)}
-                          isStreaming={gptR1Streaming}
-                          round="round1"
-                          complete={gptR1Complete}
-                        />
-                        {gptAdvisorReviewing ? (
-                          <p className="text-xs text-[#888888]" role="status" aria-live="polite">
-                            ⚖ advisor reviewing...
-                          </p>
-                        ) : null}
-                      </>
-                    )}
-                  </div>
-                )}
-                {grokRoundActive && (
-                  <div className="min-w-0 space-y-1">
-                    {showGrokThinking ? (
-                      <ThinkingDotsBubble label={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>} color={MODEL_HEX.Grok} />
-                    ) : grokR1Complete && isSkipNotice(grokR1) ? (
-                      <p className="text-xs text-[#888888]" role="status">
-                        Grok is unavailable right now — skipped this round.
-                      </p>
-                    ) : (
-                      <>
-                        <ModelBubble
-                          sender="Grok"
-                          titleOverride={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>}
-                          content={bubbleBody(grokR1, grokR1Complete)}
-                          isStreaming={grokR1Streaming}
-                          round="round1"
-                          complete={grokR1Complete}
-                        />
-                        {grokAdvisorReviewing ? (
-                          <p className="text-xs text-[#888888]" role="status" aria-live="polite">
-                            ⚖ advisor reviewing...
-                          </p>
-                        ) : null}
-                      </>
-                    )}
-                  </div>
-                )}
-                {claudeR1RoundActive && (
-                  <div className="min-w-0 space-y-1">
-                    {showClaudeR1Thinking ? (
-                      <ThinkingDotsBubble label="🟠 CLAUDE" color={MODEL_HEX.Claude} />
-                    ) : claudeR1Complete && isSkipNotice(claudeR1) ? (
-                      <p className="text-xs text-[#888888]" role="status">
-                        Claude is unavailable right now — skipped this round.
-                      </p>
-                    ) : (
-                      <ModelBubble
-                        sender="Claude"
-                        titleOverride="🟠 CLAUDE"
-                        content={bubbleBody(claudeR1, claudeR1Complete)}
-                        isStreaming={claudeR1Streaming}
-                        round="round1"
-                        complete={claudeR1Complete}
-                      />
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {perplexityPhase !== "off" && (
-                <div className="w-full min-w-0 space-y-4">
-                  <h2 className="text-xs font-semibold uppercase tracking-wide text-text-secondary">
-                    Fact-Check
-                  </h2>
-                  {perplexityPhase === "thinking" && (
-                    <ThinkingDotsBubble
-                      label="🔎 PERPLEXITY"
-                      color={MODEL_HEX.Perplexity}
-                    />
-                  )}
-                  {perplexityPhase === "content" && String(perplexityContent).trim() && (
-                    <ModelBubble
-                      sender="Perplexity"
-                      content={perplexityContent}
-                      isStreaming={false}
-                      round="audit"
-                      complete
-                      titleOverride="🔎 PERPLEXITY"
-                    />
-                  )}
-                </div>
-              )}
-            </>
-          )}
-
-          {inlineAlert && (
-            <p
-              className="max-w-[min(100%,40rem)] rounded-lg border border-red-900/50 bg-surface px-4 py-3 text-sm text-red-400"
-              role="alert"
-            >
-              {inlineAlert}
-            </p>
-          )}
-        </section>
-
-        {(synthesisThinking ||
-          synthesisStreaming ||
-          synthesisFinal ||
-          synthesisText.length > 0) && (
-          <section aria-label="Synthesis" className="space-y-4">
-            {synthesisThinking && !synthesisFinal && !String(synthesisText).trim() && (
-              <ThinkingDotsBubble
-                label="🟠 CLAUDE"
-                color={MODEL_HEX.Claude}
-                subtitle="Synthesizing your roundtable..."
-              />
-            )}
-            {(synthesisStreaming || synthesisFinal || synthesisText.length > 0) && (
-              <SynthesisPanel
-                content={synthesisBody}
-                isStreaming={synthesisStreaming && !synthesisFinal}
-                complete={synthesisFinal}
-              />
-            )}
-            {sessionComplete && annotations.length > 0 && (
-              <div className="rounded-lg border border-border bg-[#161616]" style={{ borderLeft: "3px solid #2a2a2a" }}>
-                <button
-                  type="button"
-                  onClick={() => setAnnotationsOpen((o) => !o)}
-                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-xs text-text-secondary transition-colors hover:text-text-primary focus:outline-none"
-                  aria-expanded={annotationsOpen}
-                >
-                  <span aria-hidden style={{ display: "inline-block", transform: annotationsOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                  How Claude synthesized this
-                </button>
-                {annotationsOpen && (
-                  <ul className="space-y-1.5 px-4 pb-4 pt-1">
-                    {annotations.map((a, i) => (
-                      <li key={i} className="flex gap-2 text-xs leading-relaxed text-text-secondary">
-                        <span className="shrink-0 text-[#444444]">•</span>
-                        <span>{a}</span>
-                      </li>
-                    ))}
-                  </ul>
                 )}
               </div>
             )}
           </section>
+        )}
+
+        {/* ── FACT-CHECK — shown when Perplexity started ── */}
+        {perplexityPhase !== "off" && (
+          <section aria-label="Fact-check" className="space-y-3">
+            <StageHeader
+              label="FACT-CHECK"
+              summary="Perplexity · audit complete"
+              done={factcheckStageDone}
+              open={factcheckOpen}
+              onToggle={() => setFactcheckOpen((o) => !o)}
+              active={perplexityPhase === "thinking"}
+            />
+            {/* Content: show when active OR when done+open */}
+            {(!factcheckStageDone || factcheckOpen) && (
+              <div className="space-y-2">
+                {perplexityPhase === "thinking" && (
+                  <ThinkingDotsBubble label="🔎 PERPLEXITY" color={MODEL_HEX.Perplexity} />
+                )}
+                {perplexityPhase === "content" && String(perplexityContent).trim() && (
+                  <ModelBubble
+                    sender="Perplexity"
+                    content={perplexityContent}
+                    isStreaming={false}
+                    round="audit"
+                    complete
+                    titleOverride="🔎 PERPLEXITY"
+                  />
+                )}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* ── RESEARCH — shown when session started; collapses when fact-check begins ── */}
+        {showTranscriptRoundtable && (
+          <section aria-label="Research" className="space-y-3">
+            <StageHeader
+              label="RESEARCH"
+              summary="Claude · Gemini · GPT · Grok"
+              done={researchStageDone}
+              open={researchOpen}
+              onToggle={() => setResearchOpen((o) => !o)}
+              active={!researchStageDone}
+            />
+            {/* Content: show when active OR when done+open */}
+            {(!researchStageDone || researchOpen) && (
+              <div className="space-y-4">
+                {/* Alphabetical order: Claude, Gemini, GPT, Grok */}
+
+                {/* Claude */}
+                {claudeR1RoundActive && (
+                  <div className="min-w-0">
+                    {researchStageDone && (
+                      <button
+                        type="button"
+                        onClick={() => setModelOpen((s) => ({ ...s, claude: !s.claude }))}
+                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
+                      >
+                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.claude ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                        Claude
+                      </button>
+                    )}
+                    {(!researchStageDone || modelOpen.claude) && (
+                      <div className="space-y-1">
+                        {showClaudeR1Thinking ? (
+                          <ThinkingDotsBubble label="🟠 CLAUDE" color={MODEL_HEX.Claude} />
+                        ) : claudeR1Complete && isSkipNotice(claudeR1) ? (
+                          <p className="text-xs text-[#888888]" role="status">Claude is unavailable right now — skipped this round.</p>
+                        ) : (
+                          <ModelBubble
+                            sender="Claude"
+                            titleOverride="🟠 CLAUDE"
+                            content={bubbleBody(claudeR1, claudeR1Complete)}
+                            isStreaming={claudeR1Streaming}
+                            round="round1"
+                            complete={claudeR1Complete}
+                          />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Gemini */}
+                {geminiRoundActive && (
+                  <div className="min-w-0">
+                    {researchStageDone && (
+                      <button
+                        type="button"
+                        onClick={() => setModelOpen((s) => ({ ...s, gemini: !s.gemini }))}
+                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
+                      >
+                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.gemini ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                        Gemini
+                      </button>
+                    )}
+                    {(!researchStageDone || modelOpen.gemini) && (
+                      <div className="space-y-1">
+                        {showGeminiThinking ? (
+                          <ThinkingDotsBubble label="🔵 GEMINI" color={MODEL_HEX.Gemini} />
+                        ) : geminiR1Complete && isSkipNotice(geminiR1) ? (
+                          <p className="text-xs text-[#888888]" role="status">Gemini is unavailable right now — skipped this round.</p>
+                        ) : (
+                          <>
+                            <ModelBubble
+                              sender="Gemini"
+                              titleOverride="🔵 GEMINI"
+                              content={bubbleBody(geminiR1, geminiR1Complete)}
+                              isStreaming={geminiR1Streaming}
+                              round="round1"
+                              complete={geminiR1Complete}
+                            />
+                            {geminiAdvisorReviewing && (
+                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* GPT */}
+                {gptRoundActive && (
+                  <div className="min-w-0">
+                    {researchStageDone && (
+                      <button
+                        type="button"
+                        onClick={() => setModelOpen((s) => ({ ...s, gpt: !s.gpt }))}
+                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
+                      >
+                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.gpt ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                        GPT
+                      </button>
+                    )}
+                    {(!researchStageDone || modelOpen.gpt) && (
+                      <div className="space-y-1">
+                        {showGptThinking ? (
+                          <ThinkingDotsBubble label="🟢 GPT" color={MODEL_HEX.GPT} />
+                        ) : gptR1Complete && isSkipNotice(gptR1) ? (
+                          <p className="text-xs text-[#888888]" role="status">GPT is unavailable right now — skipped this round.</p>
+                        ) : (
+                          <>
+                            <ModelBubble
+                              sender="GPT"
+                              titleOverride="🟢 GPT"
+                              content={bubbleBody(gptR1, gptR1Complete)}
+                              isStreaming={gptR1Streaming}
+                              round="round1"
+                              complete={gptR1Complete}
+                            />
+                            {gptAdvisorReviewing && (
+                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Grok */}
+                {grokRoundActive && (
+                  <div className="min-w-0">
+                    {researchStageDone && (
+                      <button
+                        type="button"
+                        onClick={() => setModelOpen((s) => ({ ...s, grok: !s.grok }))}
+                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
+                      >
+                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.grok ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                        Grok
+                      </button>
+                    )}
+                    {(!researchStageDone || modelOpen.grok) && (
+                      <div className="space-y-1">
+                        {showGrokThinking ? (
+                          <ThinkingDotsBubble label={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>} color={MODEL_HEX.Grok} />
+                        ) : grokR1Complete && isSkipNotice(grokR1) ? (
+                          <p className="text-xs text-[#888888]" role="status">Grok is unavailable right now — skipped this round.</p>
+                        ) : (
+                          <>
+                            <ModelBubble
+                              sender="Grok"
+                              titleOverride={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>}
+                              content={bubbleBody(grokR1, grokR1Complete)}
+                              isStreaming={grokR1Streaming}
+                              round="round1"
+                              complete={grokR1Complete}
+                            />
+                            {grokAdvisorReviewing && (
+                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                            )}
+                          </>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+        )}
+
+        {/* Alerts */}
+        {inlineAlert && (
+          <p
+            className="max-w-[min(100%,40rem)] rounded-lg border border-red-900/50 bg-surface px-4 py-3 text-sm text-red-400"
+            role="alert"
+          >
+            {inlineAlert}
+          </p>
         )}
 
         {sessionComplete && (

--- a/tests/test_gemini_intake.py
+++ b/tests/test_gemini_intake.py
@@ -104,10 +104,10 @@ def test_clarification_answer_completes_session():
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Tier is always one of "quick", "smart", "deep"
+# Test 4: Tier is "smart" or "deep" (both valid, "quick" is not)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("tier", ["smart"])
+@pytest.mark.parametrize("tier", ["smart", "deep"])
 def test_tier_is_valid_literal(tier):
     decision = _decision(tier=tier)
     with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=decision):
@@ -128,7 +128,7 @@ def test_invalid_tier_raises_validation_error():
 
 
 def test_quick_tier_is_invalid_for_intake():
-    """Intake always returns smart — quick is no longer a valid IntakeDecision tier."""
+    """quick is not a valid IntakeDecision tier — only smart and deep."""
     with pytest.raises(ValidationError):
         IntakeDecision(
             needs_clarification=False,
@@ -139,17 +139,62 @@ def test_quick_tier_is_invalid_for_intake():
         )
 
 
-def test_deep_tier_is_invalid_for_intake():
-    """Intake always returns smart — deep is no longer a valid IntakeDecision tier.
-    Users may upgrade to deep via the frontend confirmation modal."""
-    with pytest.raises(ValidationError):
-        IntakeDecision(
-            needs_clarification=False,
-            optimized_prompt="Test",
-            tier="deep",
-            output_type="report",
-            reasoning="test",
-        )
+def test_deep_tier_is_valid_for_intake():
+    """Intake now assigns deep for high-stakes questions — deep is a valid literal."""
+    decision = IntakeDecision(
+        needs_clarification=False,
+        optimized_prompt="Design the data architecture for a real-time fraud detection system",
+        tier="deep",
+        output_type="decision",
+        reasoning="Deep selected — architecture decision with significant real-time constraints",
+    )
+    assert decision.tier == "deep"
+
+
+def test_deep_assignment_is_honoured_in_session_config():
+    """When intake assigns deep, the session config must reflect tier='deep'."""
+    deep_decision = _decision(
+        tier="deep",
+        output_type="decision",
+        reasoning="Deep selected — architecture decision",
+        optimized_prompt="Design the architecture for a real-time fraud detection system",
+    )
+    with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=deep_decision):
+        session = IntakeSession()
+        result = session.analyze("Design the architecture for a real-time fraud detection system")
+
+    assert result["config"]["tier"] == "deep"
+
+
+def test_architecture_prompt_maps_to_deep_tier():
+    """Architecture decision prompts should receive deep tier from intake.
+    This verifies the session pipeline honours deep assignment from intake."""
+    arch_decision = _decision(
+        tier="deep",
+        output_type="decision",
+        reasoning="Deep selected — architecture decision requiring comprehensive analysis",
+        optimized_prompt="Design the architecture for a real-time data processing pipeline",
+    )
+    with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=arch_decision):
+        session = IntakeSession()
+        result = session.analyze("Design the architecture for a real-time data processing pipeline")
+
+    assert result["config"]["tier"] == "deep"
+
+
+def test_comparison_prompt_maps_to_smart_tier():
+    """Comparison prompts (X vs Y) should receive smart tier — standard analysis."""
+    comparison_decision = _decision(
+        tier="smart",
+        output_type="comparison",
+        reasoning="Smart selected — comparison question with well-defined parameters",
+        optimized_prompt="Compare PostgreSQL vs MongoDB for a read-heavy web application",
+    )
+    with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=comparison_decision):
+        session = IntakeSession()
+        result = session.analyze("Compare PostgreSQL vs MongoDB for a read-heavy web application")
+
+    assert result["config"]["tier"] == "smart"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -139,37 +139,57 @@ class TestEnvVarOverride:
         importlib.reload(mc)
 
 
-# ── Factcheck token limits ────────────────────────────────────────────────────
+# ── Factcheck token limits — always deep ─────────────────────────────────────
 
 class TestFactcheckTokenLimits:
-    def test_smart_max_tokens_is_800(self):
-        assert get_factcheck_max_tokens("smart") == 800
+    def test_smart_tier_returns_deep_max_tokens(self):
+        """Smart tier now uses deep audit depth — fact-check is always deep."""
+        from backend.models.model_config import FACTCHECK_DEEP_MAX_TOKENS
+        assert get_factcheck_max_tokens("smart") == FACTCHECK_DEEP_MAX_TOKENS
 
-    def test_deep_max_tokens_is_2000(self):
+    def test_deep_tier_returns_deep_max_tokens(self):
+        from backend.models.model_config import FACTCHECK_DEEP_MAX_TOKENS
+        assert get_factcheck_max_tokens("deep") == FACTCHECK_DEEP_MAX_TOKENS
+
+    def test_unknown_tier_returns_deep_max_tokens(self):
+        """Any tier value (incl. unknown) returns the deep limit — always 2000."""
+        from backend.models.model_config import FACTCHECK_DEEP_MAX_TOKENS
+        assert get_factcheck_max_tokens("quick") == FACTCHECK_DEEP_MAX_TOKENS
+        assert get_factcheck_max_tokens("unknown") == FACTCHECK_DEEP_MAX_TOKENS
+
+    def test_always_deep_value_is_2000(self):
+        """The always-deep token budget must be 2000."""
+        assert get_factcheck_max_tokens("smart") == 2000
         assert get_factcheck_max_tokens("deep") == 2000
 
-    def test_unknown_tier_returns_smart_limit(self):
-        """Any non-deep tier should return the smart limit."""
-        assert get_factcheck_max_tokens("quick") == 800
-        assert get_factcheck_max_tokens("unknown") == 800
 
+# ── Intake tier assignment ────────────────────────────────────────────────────
 
-# ── Intake tier lock ──────────────────────────────────────────────────────────
-
-class TestIntakeTierLock:
-    def test_intake_system_prompt_always_smart(self):
-        """Intake system prompt must mandate tier = 'smart' only."""
+class TestIntakeTierAssignment:
+    def test_intake_system_prompt_assigns_smart_or_deep(self):
+        """Intake now assigns smart OR deep based on prompt complexity."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
-        assert 'ALWAYS return "smart"' in prompt
+        assert '"smart" | "deep"' in prompt or '"smart" or "deep"' in prompt or "smart" in prompt and "deep" in prompt
 
-    def test_intake_system_prompt_no_deep_assignment(self):
-        """Intake system prompt must not instruct model to assign deep tier."""
+    def test_intake_system_prompt_conservative_deep_rule(self):
+        """Intake system prompt must instruct the model to be conservative with deep."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
-        # The prompt must not suggest deep as an assignable option
-        assert "deep  :" not in prompt
-        assert "- deep" not in prompt
+        assert "Be conservative" in prompt
+        assert "When in doubt, assign smart" in prompt
+
+    def test_intake_system_prompt_deep_criteria_includes_architecture(self):
+        """Intake system prompt must include architecture decisions as deep criteria."""
+        from backend.models.openai_client import _build_intake_system_prompt
+        prompt = _build_intake_system_prompt()
+        assert "Architecture decision" in prompt or "architecture" in prompt.lower()
+
+    def test_intake_system_prompt_no_downgrade_rule_present(self):
+        """Intake system prompt must state that deep cannot be downgraded."""
+        from backend.models.openai_client import _build_intake_system_prompt
+        prompt = _build_intake_system_prompt()
+        assert "cannot downgrade" in prompt or "deep runs" in prompt
 
     def test_intake_system_prompt_no_quick_tier(self):
         """Intake system prompt must not reference quick tier as an option."""


### PR DESCRIPTION
## What
All product decisions from April 19, 2026 session.

## Backend
- Factcheck always uses deep audit depth (2000 tokens) regardless of tier
- Intake assigns smart or deep based on prompt complexity
- IntakeDecision.tier restored to Literal["smart", "deep"]
- No downgrade rule — deep assigned by intake runs, no override

## Frontend
- One-directional tier slider: smart → deep upgrade only, locks on flip
- Deep assigned by intake: static badge, no slider, no controls
- Reversed pipeline layout: PROMPT fixed top, active stage below, completed collapsed
- Model order alphabetical: Claude, Gemini, GPT, Grok
- Session notes panel: hidden when no noteworthy events

## Docs
- ADR 003 addendum: intake now assigns deep when warranted
- ADR 004 addendum: always deep factcheck rationale

## Tests
- 183 passing (7 new)
- Always-deep token assertions
- Intake tier assignment criteria tests
- No-downgrade rule enforced at schema level