### PR TITLE
feat: UX overhaul — reversed pipeline, always-deep factcheck, save session, citations

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -348,7 +348,7 @@ async def session_run(req: SessionRunRequest):
 
     # ── Perplexity audit (Phase 2) with fallback ──────────────────────────────
     try:
-        audit_text, factcheck_provider = await asyncio.to_thread(
+        audit_text, factcheck_provider, _ = await asyncio.to_thread(
             audit_with_fallback,
             {"gemini": gemini_text, "gpt": gpt_text,
              "grok": grok_text, "claude": claude_r1_text},
@@ -990,7 +990,7 @@ async def session_websocket(websocket: WebSocket):
         # ── Perplexity audit (Phase 2) with fallback ──────────────────────────
         await websocket.send_json({"type": "perplexity_thinking"})
         try:
-            audit_text, factcheck_provider = await asyncio.to_thread(
+            audit_text, factcheck_provider, citations = await asyncio.to_thread(
                 audit_with_fallback,
                 {"gemini": gemini_text, "gpt": gpt_text,
                  "grok": grok_text, "claude": claude_r1_text},
@@ -1000,10 +1000,15 @@ async def session_websocket(websocket: WebSocket):
         except Exception as exc:
             audit_text = f"[Perplexity audit unavailable: {exc}]"
             factcheck_provider = "emergency"
+            citations = []
         health.factcheck_model = factcheck_provider
         health.factcheck_degraded = (factcheck_provider != "primary")
         transcript.add_model_message("Perplexity", audit_text, round="audit")
-        await websocket.send_json({"type": "perplexity_complete", "content": audit_text})
+        await websocket.send_json({
+            "type": "perplexity_complete",
+            "content": audit_text,
+            "citations": citations,
+        })
 
         # ── Synthesis: route to analytical or factual model based on audit ────
         synthesis_model_id, synthesis_route = select_synthesis_model(audit_text)

--- a/backend/models/intake_decision.py
+++ b/backend/models/intake_decision.py
@@ -14,7 +14,7 @@ class IntakeDecision(BaseModel):
     needs_clarification: bool
     clarifying_question: Optional[str] = None  # only when needs_clarification is True
     optimized_prompt: str        # refined, context-enriched version of user's raw prompt
-    tier: Literal["smart", "deep"]  # intake assigns based on prompt complexity
+    tier: Literal["smart"]           # intake always returns smart; user controls via UI
     output_type: str             # e.g. "report", "plan", "decision", "brainstorm", "analysis"
     reasoning: str               # one sentence shown in UI:
                                  # "Deep selected — architecture decision with significant tradeoffs"

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -66,7 +66,7 @@ Return a JSON object with exactly these fields:
   "needs_clarification": bool,
   "clarifying_question": string or null,
   "optimized_prompt": string,
-  "tier": "smart" | "deep",
+  "tier": "smart",
   "output_type": string,
   "reasoning": string
 }
@@ -86,33 +86,12 @@ Return a JSON object with exactly these fields:
 4. optimized_prompt: refined, context-enriched version of the user's
    prompt. Preserve ALL user-provided proper nouns exactly.
 
-5. tier assignment — assign the tier the question deserves:
-
-   "smart": the default for most sessions.
-   - Analysis, recommendations, research, comparisons
-   - Technical evaluations and factual questions
-   - "What is...", "Compare X vs Y", "Explain how...", "What are the risks of..."
-   - Questions where getting it 80% right is sufficient
-
-   "deep": assign when the question involves high-stakes decisions
-   or complex multi-dimensional problems where getting it wrong has
-   real consequences.
-   - Architecture decisions: "Design the architecture for..."
-   - Build vs buy decisions: "Should we build or buy..."
-   - Strategic decisions: "What is our go-to-market strategy for..."
-   - Investment or hiring decisions
-   - Questions where getting it wrong has serious consequences
-
-   Be conservative — most questions are smart.
-   When in doubt, assign smart.
-
-   IMPORTANT: The user cannot downgrade a deep assignment. If you
-   assign deep, deep runs. Assign deep only when genuinely warranted.
+5. tier: always return "smart". The user controls tier via the session UI.
 
 6. output_type: e.g. "analysis", "comparison", "report", "plan",
    "decision", "research", "factual answer"
 
-7. reasoning: one sentence explaining tier assignment and prompt direction.
+7. reasoning: one sentence explaining prompt direction and output type.
 
 Return valid JSON only. No prose outside the JSON object.
 """

--- a/backend/models/perplexity_client.py
+++ b/backend/models/perplexity_client.py
@@ -164,10 +164,24 @@ def _call_perplexity_audit(
     tier: str,
     model: str = None,
 ) -> str:
-    """Call Perplexity audit API with the given model."""
+    """Call Perplexity audit API with the given model. Returns content only (legacy)."""
     req = _build_audit_request(round1_responses, research_text, tier, model=model)
     response = _get_client().chat.completions.create(**req)
     return response.choices[0].message.content.strip()
+
+
+def _call_perplexity_audit_with_citations(
+    round1_responses: dict,
+    research_text: str,
+    tier: str,
+    model: str = None,
+) -> tuple:
+    """Call Perplexity audit API. Returns (content_str, citations_list)."""
+    req = _build_audit_request(round1_responses, research_text, tier, model=model)
+    response = _get_client().chat.completions.create(**req)
+    content = response.choices[0].message.content.strip()
+    citations = list(getattr(response, "citations", None) or [])
+    return content, citations
 
 
 def _call_gpt_audit_with_web_search(
@@ -202,7 +216,7 @@ def audit_with_fallback(
 ) -> tuple:
     """
     Run Perplexity audit with fallback chain.
-    Returns (audit_text, provider_used).
+    Returns (audit_text, provider_used, citations_list).
 
     Chain:
         Primary:   Perplexity Sonar Pro  (FACTCHECK_PRIMARY)
@@ -210,12 +224,35 @@ def audit_with_fallback(
         Fallback2: GPT-5.4 + web search  (FACTCHECK_FALLBACK2, cross-provider)
         Emergency: Degraded notice string (never raises)
 
-    Both Perplexity tiers use the same Smart/Deep audit prompt.
+    Citations are extracted from Perplexity responses (list of URL strings).
+    Fallback2 and emergency return an empty citations list.
     """
     from backend.models.resilient_caller import call_with_fallback as _call_with_fallback
     from backend.models.model_config import FACTCHECK_PRIMARY, FACTCHECK_FALLBACK1
 
-    def _emergency_factcheck() -> str:
+    # Mutable container so closures can write citations out to the caller.
+    citations_holder: list = []
+
+    def _primary():
+        content, citations = _call_perplexity_audit_with_citations(
+            round1_responses, research_text, tier, model=FACTCHECK_PRIMARY,
+        )
+        citations_holder[:] = citations
+        return content
+
+    def _fallback1():
+        content, citations = _call_perplexity_audit_with_citations(
+            round1_responses, research_text, tier, model=FACTCHECK_FALLBACK1,
+        )
+        citations_holder[:] = citations
+        return content
+
+    def _fallback2():
+        citations_holder[:] = []
+        return _call_gpt_audit_with_web_search(round1_responses, research_text, tier)
+
+    def _emergency():
+        citations_holder[:] = []
         return (
             "[Fact-check unavailable — all fact-check providers failed. "
             "Synthesis is based on round-1 model responses only. "
@@ -223,23 +260,13 @@ def audit_with_fallback(
             "Verify key facts against official sources before acting.]"
         )
 
-    return _call_with_fallback(
-        primary_fn=lambda: _call_perplexity_audit(
-            round1_responses, research_text, tier,
-            model=FACTCHECK_PRIMARY,
-        ),
-        fallback_fns=[
-            lambda: _call_perplexity_audit(
-                round1_responses, research_text, tier,
-                model=FACTCHECK_FALLBACK1,
-            ),
-            lambda: _call_gpt_audit_with_web_search(
-                round1_responses, research_text, tier,
-            ),
-        ],
-        emergency_fn=_emergency_factcheck,
+    result, provider = _call_with_fallback(
+        primary_fn=_primary,
+        fallback_fns=[_fallback1, _fallback2],
+        emergency_fn=_emergency,
         role="factcheck",
     )
+    return result, provider, citations_holder
 
 
 def audit(model_responses: dict, research_text: str = "", tier: str = "smart") -> str:

--- a/frontend/src/components/IntakeFlow.jsx
+++ b/frontend/src/components/IntakeFlow.jsx
@@ -42,11 +42,9 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
   const [answer, setAnswer] = useState("");
   const [submittingAnswer, setSubmittingAnswer] = useState(false);
   const [config, setConfig] = useState(null);
-  /** Tier assigned by intake — "smart" | "deep". Immutable after set. */
-  const [intakeTier, setIntakeTier] = useState("smart");
-  /** User's current tier selection — starts at intakeTier, can only move to "deep". */
+  /** User's current tier selection — always starts at "smart", can only move to "deep". */
   const [tierChoice, setTierChoice] = useState("smart");
-  /** Once deep is selected (by intake or user), this locks — no return to smart. */
+  /** Once deep is selected, this locks — no return to smart. */
   const [tierLocked, setTierLocked] = useState(false);
   const [error, setError] = useState(null);
   const answerRef = useRef(null);
@@ -81,11 +79,8 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
           setPhase("clarifying");
         } else {
           const cfg = data.config || {};
-          const tier = cfg.tier || "smart";
           setConfig(cfg);
-          setIntakeTier(tier);
-          setTierChoice(tier);
-          setTierLocked(tier === "deep");
+          setTierChoice("smart");
           setPhase("badge");
         }
       } catch (e) {
@@ -113,11 +108,8 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
       }
       const data = await res.json();
       const cfg = data.config || {};
-      const tier = cfg.tier || "smart";
       setConfig(cfg);
-      setIntakeTier(tier);
-      setTierChoice(tier);
-      setTierLocked(tier === "deep");
+      setTierChoice("smart");
       setPhase("badge");
     } catch (e) {
       setError(e.message || "Submit failed");
@@ -236,71 +228,56 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
               <p className="mt-1.5 text-sm text-[#888888]">{config.reasoning}</p>
             </div>
 
-            {/* RESEARCH DEPTH — slider when smart, static notice when deep-locked by intake */}
-            {intakeTier === "deep" ? (
-              /* Deep assigned by intake — no controls, no appeal */
-              <div className="rounded-lg border border-[#2a2a2a] bg-[#1e1e1e] px-4 py-3">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold" style={{ color: "#F5A623" }}>
-                    🔭 Deep · Auto-selected
-                  </span>
-                </div>
-                <p className="mt-1.5 text-sm text-[#888888]">
-                  This question warrants deep analysis — top models with extended thinking.
-                </p>
-              </div>
-            ) : (
-              /* Smart assigned by intake — slider, user may upgrade to deep (one-way) */
-              <div>
-                <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[#888888]">Research Depth</p>
-                <div className="flex items-center gap-4">
-                  {/* Smart label */}
+            {/* RESEARCH DEPTH — slider always shown; user upgrades smart → deep (one-way) */}
+            <div>
+              <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[#888888]">Research Depth</p>
+              <div className="flex items-center gap-4">
+                {/* Smart label */}
+                <span
+                  className="text-sm font-medium transition-colors duration-200"
+                  style={{ color: tierChoice === "smart" ? "#e8e8e8" : "#555555" }}
+                >
+                  Smart
+                </span>
+
+                {/* Pill toggle track */}
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={tierChoice === "deep"}
+                  aria-label="Research depth — slide right to upgrade to Deep"
+                  onClick={handleSliderChange}
+                  disabled={tierLocked}
+                  className="relative h-7 w-14 flex-shrink-0 rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623] disabled:cursor-not-allowed"
+                  style={{ background: tierChoice === "deep" ? "#F5A623" : "#2a2a2a" }}
+                >
                   <span
-                    className="text-sm font-medium transition-colors duration-200"
-                    style={{ color: tierChoice === "smart" ? "#e8e8e8" : "#555555" }}
-                  >
-                    Smart
-                  </span>
+                    className="absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-[#e8e8e8] shadow transition-transform duration-200"
+                    style={{ transform: tierChoice === "deep" ? "translateX(28px)" : "translateX(0)" }}
+                  />
+                </button>
 
-                  {/* Pill toggle track */}
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={tierChoice === "deep"}
-                    aria-label="Research depth — slide right to upgrade to Deep"
-                    onClick={handleSliderChange}
-                    disabled={tierLocked}
-                    className="relative h-7 w-14 flex-shrink-0 rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F5A623] disabled:cursor-not-allowed"
-                    style={{ background: tierChoice === "deep" ? "#F5A623" : "#2a2a2a" }}
-                  >
-                    <span
-                      className="absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-[#e8e8e8] shadow transition-transform duration-200"
-                      style={{ transform: tierChoice === "deep" ? "translateX(28px)" : "translateX(0)" }}
-                    />
-                  </button>
-
-                  {/* Deep label */}
-                  <span
-                    className="text-sm font-medium transition-colors duration-200"
-                    style={{ color: tierChoice === "deep" ? "#e8e8e8" : "#555555" }}
-                  >
-                    Deep
-                  </span>
-                </div>
-
-                {/* Description — changes on toggle, locked notice when deep selected */}
-                <p className="mt-2 text-sm text-[#888888]">
-                  {tierChoice === "smart"
-                    ? "Executor + advisor per model · recommended for most sessions"
-                    : "Top models · extended thinking · for high-stakes decisions"}
-                </p>
-                {tierLocked && tierChoice === "deep" && (
-                  <p className="mt-1 text-xs text-[#555555]">
-                    Deep selected — session will run at full depth.
-                  </p>
-                )}
+                {/* Deep label */}
+                <span
+                  className="text-sm font-medium transition-colors duration-200"
+                  style={{ color: tierChoice === "deep" ? "#e8e8e8" : "#555555" }}
+                >
+                  Deep
+                </span>
               </div>
-            )}
+
+              {/* Description — changes on toggle, locked notice when deep selected */}
+              <p className="mt-2 text-sm text-[#888888]">
+                {tierChoice === "smart"
+                  ? "Executor + advisor per model · recommended for most sessions"
+                  : "Top models · extended thinking · for high-stakes decisions"}
+              </p>
+              {tierLocked && tierChoice === "deep" && (
+                <p className="mt-1 text-xs text-[#555555]">
+                  Deep selected — session will run at full depth.
+                </p>
+              )}
+            </div>
 
             {/* Confirm */}
             <div className="flex justify-end">

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -47,40 +47,6 @@ function wsUrlFromApiBase() {
 
 /** @typedef {'idle' | 'round1_parallel' | 'perplexity' | 'synthesis'} StreamPhase */
 
-/**
- * Collapsible stage header — active stages show plain label, done stages show toggle.
- */
-function StageHeader({ label, summary, done, open, onToggle, active }) {
-  if (!done) {
-    return (
-      <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary ${active ? "animate-pulse" : ""}`}>
-        {label}
-      </h2>
-    );
-  }
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className="flex w-full items-center gap-2 text-left focus:outline-none"
-      aria-expanded={open}
-    >
-      <span
-        aria-hidden
-        className="shrink-0 text-[10px] text-text-secondary"
-        style={{ display: "inline-block", transform: open ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}
-      >
-        ▾
-      </span>
-      <span className="text-xs font-semibold uppercase tracking-wide text-text-secondary">{label}</span>
-      {!open && summary && (
-        <span className="ml-1 text-xs text-[#555555]">{summary}</span>
-      )}
-      <span className="ml-auto text-xs text-[#555555]" aria-hidden>✓</span>
-    </button>
-  );
-}
-
 function timestamp() {
   return new Date().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
@@ -300,10 +266,8 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
   const [annotations, setAnnotations] = useState([]);
   const [annotationsOpen, setAnnotationsOpen] = useState(false);
 
-  // ── Synthesis collapse/expand state ──────────────────────────────────────
-  // Synthesis auto-expands when complete; user can toggle after.
-  const [synthesisOpen, setSynthesisOpen] = useState(false);
-  const synthesisAutoExpandedRef = useRef(false);
+  // ── Annotations ref — mirrors state for access inside WS closure ────────
+  const annotationsRef = useRef([]);
 
   const r1CountsRef = useRef({ Gemini: 0, GPT: 0, Grok: 0, Claude: 0 });
 
@@ -440,9 +404,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(true);
     phaseRef.current = "idle";
     r1CountsRef.current = { Gemini: ge.length, GPT: gp.length, Grok: grk.length, Claude: cla.length };
-    // Resume: synthesis auto-expanded
-    setSynthesisOpen(true);
-    synthesisAutoExpandedRef.current = true;
+    // Resume: all stages complete
   }, [resumeTranscript, sessionConfig]);
 
   useEffect(() => {
@@ -485,8 +447,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(false);
     setAnnotations([]);
     setAnnotationsOpen(false);
-    setSynthesisOpen(false);
-    synthesisAutoExpandedRef.current = false;
+    annotationsRef.current = [];
 
     const url = wsUrlFromApiBase();
 
@@ -576,9 +537,12 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             onSynthesisCompleteRef.current?.(data.content ?? "");
             break;
           case "synthesis_annotations":
+            console.log("[SESSION NOTES] synthesis_annotations received:", data.annotations);
+            annotationsRef.current = data.annotations || [];
             setAnnotations(data.annotations || []);
             break;
           case "session_complete":
+            console.log("[SESSION NOTES] session_complete fired, annotations:", annotationsRef.current);
             completedNormallyRef.current = true;
             setSessionComplete(true);
             break;
@@ -774,14 +738,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     (synthesisPhaseEntered && perplexityPhase !== "thinking");
   const synthesisStageDone = isResume || synthesisFinal;
 
-  // Auto-expand synthesis when complete (fires once on transition)
-  useEffect(() => {
-    if (synthesisStageDone && !synthesisAutoExpandedRef.current) {
-      synthesisAutoExpandedRef.current = true;
-      setSynthesisOpen(true);
-    }
-  }, [synthesisStageDone]);
-
   const showTranscriptRoundtable = isResume || sessionStarted;
 
   const showGeminiThinking =
@@ -819,8 +775,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     claudeR1Streaming ||
     (Boolean(String(claudeR1 || "").trim()) && !isSkipNotice(claudeR1)) ||
     (claudeR1Complete && !isSkipNotice(claudeR1));
-
-  const round1GridClass = "flex flex-col gap-4";
 
   return (
     <div className="min-h-screen bg-bg text-text-primary">
@@ -909,65 +863,57 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
             Optimized Prompt
           </h2>
-          <div className="bubble-scroll max-h-[3rem] overflow-y-auto rounded-lg border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text-primary whitespace-pre-wrap">
+          <div className="bubble-scroll max-h-[6rem] overflow-y-auto rounded-lg border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text-primary whitespace-pre-wrap">
             {displayPrompt || "—"}
           </div>
         </section>
 
-        {/* ── SYNTHESIS — shown when phase entered; sits immediately below PROMPT ── */}
+        {/* ── SYNTHESIS — shown when phase entered; always expanded ── */}
         {synthesisPhaseEntered && (
           <section aria-label="Synthesis" className="space-y-3">
-            <StageHeader
-              label={breadcrumbState.sLabel}
-              summary={null}
-              done={synthesisStageDone}
-              open={synthesisOpen}
-              onToggle={() => setSynthesisOpen((o) => !o)}
-              active={!synthesisStageDone}
-            />
-            {/* Content: show when active OR when done+open */}
-            {(!synthesisStageDone || synthesisOpen) && (
-              <div className="space-y-4">
-                {synthesisThinking && !synthesisFinal && !String(synthesisText).trim() && (
-                  <ThinkingDotsBubble
-                    label="🟠 CLAUDE"
-                    color={MODEL_HEX.Claude}
-                    subtitle="Synthesizing your roundtable..."
-                  />
-                )}
-                {(synthesisStreaming || synthesisFinal || synthesisText.length > 0) && (
-                  <SynthesisPanel
-                    content={synthesisBody}
-                    isStreaming={synthesisStreaming && !synthesisFinal}
-                    complete={synthesisFinal}
-                  />
-                )}
-                {/* Session notes — only when there are noteworthy annotations */}
-                {sessionComplete && annotations.length > 0 && (
-                  <div className="rounded-lg border border-border bg-[#161616]" style={{ borderLeft: "3px solid #2a2a2a" }}>
-                    <button
-                      type="button"
-                      onClick={() => setAnnotationsOpen((o) => !o)}
-                      className="flex w-full items-center gap-2 px-4 py-3 text-left text-xs text-text-secondary transition-colors hover:text-text-primary focus:outline-none"
-                      aria-expanded={annotationsOpen}
-                    >
-                      <span aria-hidden style={{ display: "inline-block", transform: annotationsOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                      Session notes
-                    </button>
-                    {annotationsOpen && (
-                      <ul className="space-y-1.5 px-4 pb-4 pt-1">
-                        {annotations.map((a, i) => (
-                          <li key={i} className="flex gap-2 text-xs leading-relaxed text-text-secondary">
-                            <span className="shrink-0 text-[#444444]">·</span>
-                            <span>{a}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
+            <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${!synthesisStageDone ? " animate-pulse" : ""}`}>
+              {breadcrumbState.sLabel}
+            </h2>
+            <div className="space-y-4">
+              {synthesisThinking && !synthesisFinal && !String(synthesisText).trim() && (
+                <ThinkingDotsBubble
+                  label="🟠 CLAUDE"
+                  color={MODEL_HEX.Claude}
+                  subtitle="Synthesizing your roundtable..."
+                />
+              )}
+              {(synthesisStreaming || synthesisFinal || synthesisText.length > 0) && (
+                <SynthesisPanel
+                  content={synthesisBody}
+                  isStreaming={synthesisStreaming && !synthesisFinal}
+                  complete={synthesisFinal}
+                />
+              )}
+              {/* Session notes — only when there are noteworthy annotations */}
+              {sessionComplete && annotations.length > 0 && (
+                <div className="rounded-lg border border-border bg-[#161616]" style={{ borderLeft: "3px solid #2a2a2a" }}>
+                  <button
+                    type="button"
+                    onClick={() => setAnnotationsOpen((o) => !o)}
+                    className="flex w-full items-center gap-2 px-4 py-3 text-left text-xs text-text-secondary transition-colors hover:text-text-primary focus:outline-none"
+                    aria-expanded={annotationsOpen}
+                  >
+                    <span aria-hidden style={{ display: "inline-block", transform: annotationsOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
+                    Session notes
+                  </button>
+                  {annotationsOpen && (
+                    <ul className="space-y-1.5 px-4 pb-4 pt-1">
+                      {annotations.map((a, i) => (
+                        <li key={i} className="flex gap-2 text-xs leading-relaxed text-text-secondary">
+                          <span className="shrink-0 text-[#444444]">·</span>
+                          <span>{a}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
           </section>
         )}
 
@@ -977,7 +923,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${perplexityPhase === "thinking" ? " animate-pulse" : ""}`}>
               Fact-Check
             </h2>
-            <div className="overflow-y-auto space-y-2" style={{ maxHeight: "300px" }}>
+            <div className="space-y-2">
               {perplexityPhase === "thinking" && (
                 <ThinkingDotsBubble label="🔎 PERPLEXITY" color={MODEL_HEX.Perplexity} />
               )}
@@ -989,6 +935,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                   round="audit"
                   complete
                   titleOverride="🔎 PERPLEXITY"
+                  contentMaxHeight="300px"
                 />
               )}
             </div>
@@ -1001,8 +948,8 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${!researchStageDone ? " animate-pulse" : ""}`}>
               Research
             </h2>
-            <div className="overflow-y-auto space-y-4" style={{ maxHeight: "400px" }}>
-              {/* Alphabetical order: Claude, Gemini, GPT, Grok */}
+            {/* Alphabetical order: Claude, Gemini, GPT, Grok — each with its own scrollable bubble */}
+            <div className="space-y-4">
 
               {/* Claude */}
               {claudeR1RoundActive && (
@@ -1019,6 +966,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                       isStreaming={claudeR1Streaming}
                       round="round1"
                       complete={claudeR1Complete}
+                      contentMaxHeight="200px"
                     />
                   )}
                 </div>
@@ -1040,6 +988,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                         isStreaming={geminiR1Streaming}
                         round="round1"
                         complete={geminiR1Complete}
+                        contentMaxHeight="200px"
                       />
                       {geminiAdvisorReviewing && (
                         <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
@@ -1065,6 +1014,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                         isStreaming={gptR1Streaming}
                         round="round1"
                         complete={gptR1Complete}
+                        contentMaxHeight="200px"
                       />
                       {gptAdvisorReviewing && (
                         <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
@@ -1090,6 +1040,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                         isStreaming={grokR1Streaming}
                         round="round1"
                         complete={grokR1Complete}
+                        contentMaxHeight="200px"
                       />
                       {grokAdvisorReviewing && (
                         <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -300,17 +300,9 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
   const [annotations, setAnnotations] = useState([]);
   const [annotationsOpen, setAnnotationsOpen] = useState(false);
 
-  // ── Pipeline stage collapse/expand state ──────────────────────────────────
-  // Stages auto-collapse when complete, synthesis auto-expands.
-  // After auto-transition, user can toggle freely.
-  const [researchOpen, setResearchOpen] = useState(true);
-  const [factcheckOpen, setFactcheckOpen] = useState(true);
+  // ── Synthesis collapse/expand state ──────────────────────────────────────
+  // Synthesis auto-expands when complete; user can toggle after.
   const [synthesisOpen, setSynthesisOpen] = useState(false);
-  // Individual model sub-panel expand state inside RESEARCH (all open by default)
-  const [modelOpen, setModelOpen] = useState({ claude: true, gemini: true, gpt: true, grok: true });
-
-  const researchAutoCollapsedRef = useRef(false);
-  const factcheckAutoCollapsedRef = useRef(false);
   const synthesisAutoExpandedRef = useRef(false);
 
   const r1CountsRef = useRef({ Gemini: 0, GPT: 0, Grok: 0, Claude: 0 });
@@ -448,12 +440,8 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(true);
     phaseRef.current = "idle";
     r1CountsRef.current = { Gemini: ge.length, GPT: gp.length, Grok: grk.length, Claude: cla.length };
-    // Resume: all stages complete — research/factcheck collapsed, synthesis expanded
-    setResearchOpen(false);
-    setFactcheckOpen(false);
+    // Resume: synthesis auto-expanded
     setSynthesisOpen(true);
-    researchAutoCollapsedRef.current = true;
-    factcheckAutoCollapsedRef.current = true;
     synthesisAutoExpandedRef.current = true;
   }, [resumeTranscript, sessionConfig]);
 
@@ -497,12 +485,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(false);
     setAnnotations([]);
     setAnnotationsOpen(false);
-    setResearchOpen(true);
-    setFactcheckOpen(true);
     setSynthesisOpen(false);
-    setModelOpen({ claude: true, gemini: true, gpt: true, grok: true });
-    researchAutoCollapsedRef.current = false;
-    factcheckAutoCollapsedRef.current = false;
     synthesisAutoExpandedRef.current = false;
 
     const url = wsUrlFromApiBase();
@@ -791,22 +774,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     (synthesisPhaseEntered && perplexityPhase !== "thinking");
   const synthesisStageDone = isResume || synthesisFinal;
 
-  // Auto-collapse research when complete (fires once on transition)
-  useEffect(() => {
-    if (researchStageDone && !researchAutoCollapsedRef.current) {
-      researchAutoCollapsedRef.current = true;
-      setResearchOpen(false);
-    }
-  }, [researchStageDone]);
-
-  // Auto-collapse factcheck when complete (fires once on transition)
-  useEffect(() => {
-    if (factcheckStageDone && !factcheckAutoCollapsedRef.current) {
-      factcheckAutoCollapsedRef.current = true;
-      setFactcheckOpen(false);
-    }
-  }, [factcheckStageDone]);
-
   // Auto-expand synthesis when complete (fires once on transition)
   useEffect(() => {
     if (synthesisStageDone && !synthesisAutoExpandedRef.current) {
@@ -940,9 +907,9 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
         {/* ── PROMPT — fixed, always visible ── */}
         <section aria-label="Session prompt">
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
-            Prompt
+            Optimized Prompt
           </h2>
-          <div className="bubble-scroll max-h-[200px] rounded-lg border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text-primary whitespace-pre-wrap">
+          <div className="bubble-scroll max-h-[3rem] overflow-y-auto rounded-lg border border-border bg-surface px-4 py-3 text-sm leading-relaxed text-text-primary whitespace-pre-wrap">
             {displayPrompt || "—"}
           </div>
         </section>
@@ -1007,203 +974,131 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
         {/* ── FACT-CHECK — shown when Perplexity started ── */}
         {perplexityPhase !== "off" && (
           <section aria-label="Fact-check" className="space-y-3">
-            <StageHeader
-              label="FACT-CHECK"
-              summary="Perplexity · audit complete"
-              done={factcheckStageDone}
-              open={factcheckOpen}
-              onToggle={() => setFactcheckOpen((o) => !o)}
-              active={perplexityPhase === "thinking"}
-            />
-            {/* Content: show when active OR when done+open */}
-            {(!factcheckStageDone || factcheckOpen) && (
-              <div className="space-y-2">
-                {perplexityPhase === "thinking" && (
-                  <ThinkingDotsBubble label="🔎 PERPLEXITY" color={MODEL_HEX.Perplexity} />
-                )}
-                {perplexityPhase === "content" && String(perplexityContent).trim() && (
-                  <ModelBubble
-                    sender="Perplexity"
-                    content={perplexityContent}
-                    isStreaming={false}
-                    round="audit"
-                    complete
-                    titleOverride="🔎 PERPLEXITY"
-                  />
-                )}
-              </div>
-            )}
+            <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${perplexityPhase === "thinking" ? " animate-pulse" : ""}`}>
+              Fact-Check
+            </h2>
+            <div className="overflow-y-auto space-y-2" style={{ maxHeight: "300px" }}>
+              {perplexityPhase === "thinking" && (
+                <ThinkingDotsBubble label="🔎 PERPLEXITY" color={MODEL_HEX.Perplexity} />
+              )}
+              {perplexityPhase === "content" && String(perplexityContent).trim() && (
+                <ModelBubble
+                  sender="Perplexity"
+                  content={perplexityContent}
+                  isStreaming={false}
+                  round="audit"
+                  complete
+                  titleOverride="🔎 PERPLEXITY"
+                />
+              )}
+            </div>
           </section>
         )}
 
-        {/* ── RESEARCH — shown when session started; collapses when fact-check begins ── */}
+        {/* ── RESEARCH — shown when session started ── */}
         {showTranscriptRoundtable && (
           <section aria-label="Research" className="space-y-3">
-            <StageHeader
-              label="RESEARCH"
-              summary="Claude · Gemini · GPT · Grok"
-              done={researchStageDone}
-              open={researchOpen}
-              onToggle={() => setResearchOpen((o) => !o)}
-              active={!researchStageDone}
-            />
-            {/* Content: show when active OR when done+open */}
-            {(!researchStageDone || researchOpen) && (
-              <div className="space-y-4">
-                {/* Alphabetical order: Claude, Gemini, GPT, Grok */}
+            <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${!researchStageDone ? " animate-pulse" : ""}`}>
+              Research
+            </h2>
+            <div className="overflow-y-auto space-y-4" style={{ maxHeight: "400px" }}>
+              {/* Alphabetical order: Claude, Gemini, GPT, Grok */}
 
-                {/* Claude */}
-                {claudeR1RoundActive && (
-                  <div className="min-w-0">
-                    {researchStageDone && (
-                      <button
-                        type="button"
-                        onClick={() => setModelOpen((s) => ({ ...s, claude: !s.claude }))}
-                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
-                      >
-                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.claude ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                        Claude
-                      </button>
-                    )}
-                    {(!researchStageDone || modelOpen.claude) && (
-                      <div className="space-y-1">
-                        {showClaudeR1Thinking ? (
-                          <ThinkingDotsBubble label="🟠 CLAUDE" color={MODEL_HEX.Claude} />
-                        ) : claudeR1Complete && isSkipNotice(claudeR1) ? (
-                          <p className="text-xs text-[#888888]" role="status">Claude is unavailable right now — skipped this round.</p>
-                        ) : (
-                          <ModelBubble
-                            sender="Claude"
-                            titleOverride="🟠 CLAUDE"
-                            content={bubbleBody(claudeR1, claudeR1Complete)}
-                            isStreaming={claudeR1Streaming}
-                            round="round1"
-                            complete={claudeR1Complete}
-                          />
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
+              {/* Claude */}
+              {claudeR1RoundActive && (
+                <div className="min-w-0 space-y-1">
+                  {showClaudeR1Thinking ? (
+                    <ThinkingDotsBubble label="🟠 CLAUDE" color={MODEL_HEX.Claude} />
+                  ) : claudeR1Complete && isSkipNotice(claudeR1) ? (
+                    <p className="text-xs text-[#888888]" role="status">Claude is unavailable right now — skipped this round.</p>
+                  ) : (
+                    <ModelBubble
+                      sender="Claude"
+                      titleOverride="🟠 CLAUDE"
+                      content={bubbleBody(claudeR1, claudeR1Complete)}
+                      isStreaming={claudeR1Streaming}
+                      round="round1"
+                      complete={claudeR1Complete}
+                    />
+                  )}
+                </div>
+              )}
 
-                {/* Gemini */}
-                {geminiRoundActive && (
-                  <div className="min-w-0">
-                    {researchStageDone && (
-                      <button
-                        type="button"
-                        onClick={() => setModelOpen((s) => ({ ...s, gemini: !s.gemini }))}
-                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
-                      >
-                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.gemini ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                        Gemini
-                      </button>
-                    )}
-                    {(!researchStageDone || modelOpen.gemini) && (
-                      <div className="space-y-1">
-                        {showGeminiThinking ? (
-                          <ThinkingDotsBubble label="🔵 GEMINI" color={MODEL_HEX.Gemini} />
-                        ) : geminiR1Complete && isSkipNotice(geminiR1) ? (
-                          <p className="text-xs text-[#888888]" role="status">Gemini is unavailable right now — skipped this round.</p>
-                        ) : (
-                          <>
-                            <ModelBubble
-                              sender="Gemini"
-                              titleOverride="🔵 GEMINI"
-                              content={bubbleBody(geminiR1, geminiR1Complete)}
-                              isStreaming={geminiR1Streaming}
-                              round="round1"
-                              complete={geminiR1Complete}
-                            />
-                            {geminiAdvisorReviewing && (
-                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
-                            )}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
+              {/* Gemini */}
+              {geminiRoundActive && (
+                <div className="min-w-0 space-y-1">
+                  {showGeminiThinking ? (
+                    <ThinkingDotsBubble label="🔵 GEMINI" color={MODEL_HEX.Gemini} />
+                  ) : geminiR1Complete && isSkipNotice(geminiR1) ? (
+                    <p className="text-xs text-[#888888]" role="status">Gemini is unavailable right now — skipped this round.</p>
+                  ) : (
+                    <>
+                      <ModelBubble
+                        sender="Gemini"
+                        titleOverride="🔵 GEMINI"
+                        content={bubbleBody(geminiR1, geminiR1Complete)}
+                        isStreaming={geminiR1Streaming}
+                        round="round1"
+                        complete={geminiR1Complete}
+                      />
+                      {geminiAdvisorReviewing && (
+                        <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
 
-                {/* GPT */}
-                {gptRoundActive && (
-                  <div className="min-w-0">
-                    {researchStageDone && (
-                      <button
-                        type="button"
-                        onClick={() => setModelOpen((s) => ({ ...s, gpt: !s.gpt }))}
-                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
-                      >
-                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.gpt ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                        GPT
-                      </button>
-                    )}
-                    {(!researchStageDone || modelOpen.gpt) && (
-                      <div className="space-y-1">
-                        {showGptThinking ? (
-                          <ThinkingDotsBubble label="🟢 GPT" color={MODEL_HEX.GPT} />
-                        ) : gptR1Complete && isSkipNotice(gptR1) ? (
-                          <p className="text-xs text-[#888888]" role="status">GPT is unavailable right now — skipped this round.</p>
-                        ) : (
-                          <>
-                            <ModelBubble
-                              sender="GPT"
-                              titleOverride="🟢 GPT"
-                              content={bubbleBody(gptR1, gptR1Complete)}
-                              isStreaming={gptR1Streaming}
-                              round="round1"
-                              complete={gptR1Complete}
-                            />
-                            {gptAdvisorReviewing && (
-                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
-                            )}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
+              {/* GPT */}
+              {gptRoundActive && (
+                <div className="min-w-0 space-y-1">
+                  {showGptThinking ? (
+                    <ThinkingDotsBubble label="🟢 GPT" color={MODEL_HEX.GPT} />
+                  ) : gptR1Complete && isSkipNotice(gptR1) ? (
+                    <p className="text-xs text-[#888888]" role="status">GPT is unavailable right now — skipped this round.</p>
+                  ) : (
+                    <>
+                      <ModelBubble
+                        sender="GPT"
+                        titleOverride="🟢 GPT"
+                        content={bubbleBody(gptR1, gptR1Complete)}
+                        isStreaming={gptR1Streaming}
+                        round="round1"
+                        complete={gptR1Complete}
+                      />
+                      {gptAdvisorReviewing && (
+                        <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
 
-                {/* Grok */}
-                {grokRoundActive && (
-                  <div className="min-w-0">
-                    {researchStageDone && (
-                      <button
-                        type="button"
-                        onClick={() => setModelOpen((s) => ({ ...s, grok: !s.grok }))}
-                        className="mb-1 flex items-center gap-1 text-xs text-[#555555] hover:text-text-secondary focus:outline-none"
-                      >
-                        <span aria-hidden style={{ display: "inline-block", transform: modelOpen.grok ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                        Grok
-                      </button>
-                    )}
-                    {(!researchStageDone || modelOpen.grok) && (
-                      <div className="space-y-1">
-                        {showGrokThinking ? (
-                          <ThinkingDotsBubble label={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>} color={MODEL_HEX.Grok} />
-                        ) : grokR1Complete && isSkipNotice(grokR1) ? (
-                          <p className="text-xs text-[#888888]" role="status">Grok is unavailable right now — skipped this round.</p>
-                        ) : (
-                          <>
-                            <ModelBubble
-                              sender="Grok"
-                              titleOverride={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>}
-                              content={bubbleBody(grokR1, grokR1Complete)}
-                              isStreaming={grokR1Streaming}
-                              round="round1"
-                              complete={grokR1Complete}
-                            />
-                            {grokAdvisorReviewing && (
-                              <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
-                            )}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
+              {/* Grok */}
+              {grokRoundActive && (
+                <div className="min-w-0 space-y-1">
+                  {showGrokThinking ? (
+                    <ThinkingDotsBubble label={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>} color={MODEL_HEX.Grok} />
+                  ) : grokR1Complete && isSkipNotice(grokR1) ? (
+                    <p className="text-xs text-[#888888]" role="status">Grok is unavailable right now — skipped this round.</p>
+                  ) : (
+                    <>
+                      <ModelBubble
+                        sender="Grok"
+                        titleOverride={<><span style={{ fontSize: "1.15em", lineHeight: 1, verticalAlign: "middle" }}>●</span>{" GROK"}</>}
+                        content={bubbleBody(grokR1, grokR1Complete)}
+                        isStreaming={grokR1Streaming}
+                        round="round1"
+                        complete={grokR1Complete}
+                      />
+                      {grokAdvisorReviewing && (
+                        <p className="text-xs text-[#888888]" role="status" aria-live="polite">⚖ advisor reviewing...</p>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
           </section>
         )}
 

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -15,9 +15,8 @@ import { MODEL_HEX } from "../constants/modelColors";
 import Header from "./common/Header";
 import ModelBubble from "./common/ModelBubble";
 import SynthesisPanel from "./SynthesisPanel";
-import TakeFurther from "./TakeFurther";
-
 const DEFAULT_HTTP = "http://localhost:8000";
+const API_BASE = process.env.REACT_APP_API_URL || DEFAULT_HTTP;
 
 /** Browser WebSocket has no configurable open timeout; guard hung connects. */
 const WS_CONNECT_TIMEOUT_MS = 120_000;
@@ -104,18 +103,6 @@ function buildTranscriptDict(sessionConfig, prompt, geminiR1, gptR1, grokR1, cla
     session_config: sessionConfig,
     intake_summary: sessionConfig?.intake_summary ?? null,
   };
-}
-
-function downloadJsonFile(payload, filename) {
-  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
 }
 
 function formatTierBadge(tier) {
@@ -262,12 +249,8 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
 
   const [leaveIntent, setLeaveIntent] = useState(null);
 
-  // ── Synthesis annotations — shown in Session notes panel ────────────────
-  const [annotations, setAnnotations] = useState([]);
-  const [annotationsOpen, setAnnotationsOpen] = useState(false);
-
-  // ── Annotations ref — mirrors state for access inside WS closure ────────
-  const annotationsRef = useRef([]);
+  // ── Perplexity citations — shown below FINAL ANSWER ─────────────────────
+  const [citations, setCitations] = useState([]);
 
   const r1CountsRef = useRef({ Gemini: 0, GPT: 0, Grok: 0, Claude: 0 });
 
@@ -404,6 +387,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSessionComplete(true);
     phaseRef.current = "idle";
     r1CountsRef.current = { Gemini: ge.length, GPT: gp.length, Grok: grk.length, Claude: cla.length };
+    setCitations([]);
     // Resume: all stages complete
   }, [resumeTranscript, sessionConfig]);
 
@@ -445,9 +429,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     setSynthesisStreaming(false);
     setSynthesisFinal(false);
     setSessionComplete(false);
-    setAnnotations([]);
-    setAnnotationsOpen(false);
-    annotationsRef.current = [];
+    setCitations([]);
 
     const url = wsUrlFromApiBase();
 
@@ -520,6 +502,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             break;
           case "perplexity_complete":
             setPerplexityContent(data.content ?? "");
+            setCitations(data.citations || []);
             setPerplexityPhase("content");
             break;
           case "synthesis_thinking":
@@ -536,13 +519,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
             setStreamPhaseMarker((n) => n + 1);
             onSynthesisCompleteRef.current?.(data.content ?? "");
             break;
-          case "synthesis_annotations":
-            console.log("[SESSION NOTES] synthesis_annotations received:", data.annotations);
-            annotationsRef.current = data.annotations || [];
-            setAnnotations(data.annotations || []);
-            break;
           case "session_complete":
-            console.log("[SESSION NOTES] session_complete fired, annotations:", annotationsRef.current);
             completedNormallyRef.current = true;
             setSessionComplete(true);
             break;
@@ -622,14 +599,40 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
 
   const sessionSettled = synthesisFinal;
 
-  const downloadResumePayload = useCallback(() => {
-    const transcript = {
-      messages: transcriptForExport.messages,
-      intake_summary: transcriptForExport.intake_summary ?? null,
-    };
-    const slug = new Date().toISOString().slice(0, 10);
-    downloadJsonFile({ session_config: sessionConfig, transcript }, `ai-roundtable-session-${slug}.json`);
-  }, [sessionConfig, transcriptForExport]);
+  const downloadSessionMarkdown = useCallback(async () => {
+    if (!transcriptForExport || !sessionConfig) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/export/markdown`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode: "full", transcript: transcriptForExport, session_config: sessionConfig }),
+      });
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `ai-roundtable-${new Date().toISOString().slice(0, 10)}.md`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch { /* navigate home regardless */ }
+  }, [transcriptForExport, sessionConfig]);
+
+  const downloadFinalAnswerTxt = useCallback(() => {
+    if (!synthesisText) return;
+    const ts = new Date().toISOString().slice(0, 16).replace("T", "-").replace(":", "");
+    const blob = new Blob([synthesisText], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `final-answer-${ts}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [synthesisText]);
 
   const requestHome = useCallback(() => {
     if (!onNavigateHome) return;
@@ -637,25 +640,25 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     else setLeaveIntent("home");
   }, [onNavigateHome, sessionSettled]);
 
-  const requestSaveExit = useCallback(() => {
+  const requestSaveExit = useCallback(async () => {
     if (!onNavigateHome) return;
     if (sessionSettled) {
-      downloadResumePayload();
+      await downloadSessionMarkdown();
       onNavigateHome();
     } else {
       setLeaveIntent("save-exit");
     }
-  }, [onNavigateHome, sessionSettled, downloadResumePayload]);
+  }, [onNavigateHome, sessionSettled, downloadSessionMarkdown]);
 
-  const confirmLeave = useCallback(() => {
+  const confirmLeave = useCallback(async () => {
     const intent = leaveIntent;
     setLeaveIntent(null);
     if (!onNavigateHome) return;
     if (intent === "save-exit") {
-      downloadResumePayload();
+      await downloadSessionMarkdown();
     }
     onNavigateHome();
-  }, [leaveIntent, onNavigateHome, downloadResumePayload]);
+  }, [leaveIntent, onNavigateHome, downloadSessionMarkdown]);
 
   const inlineAlert = streamError || transportError;
   const synthesisBody =
@@ -787,11 +790,11 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
         >
           <div className="w-full max-w-md rounded-lg border border-border bg-surface px-5 py-5 shadow-lg">
             <h2 id="leave-dialog-title" className="text-base font-semibold text-text-primary">
-              {leaveIntent === "save-exit" ? "Save and exit?" : "Leave session?"}
+              {leaveIntent === "save-exit" ? "Save session and exit?" : "Leave session?"}
             </h2>
             <p className="mt-3 text-sm leading-relaxed text-text-secondary">
               {leaveIntent === "save-exit"
-                ? "Session in progress — your responses will be lost unless you save. Save a session .json file and go home?"
+                ? "Session in progress — your responses will be lost unless you save. Download a full session .md file and go home?"
                 : "Session in progress — your responses will be lost. Go home anyway?"}
             </p>
             <div className="mt-5 flex justify-end gap-2">
@@ -868,12 +871,24 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
           </div>
         </section>
 
-        {/* ── SYNTHESIS — shown when phase entered; always expanded ── */}
+        {/* ── FINAL ANSWER — shown when phase entered; always expanded ── */}
         {synthesisPhaseEntered && (
-          <section aria-label="Synthesis" className="space-y-3">
-            <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${!synthesisStageDone ? " animate-pulse" : ""}`}>
-              {breadcrumbState.sLabel}
-            </h2>
+          <section aria-label="Final answer" className="space-y-3">
+            <div className="flex items-center gap-3">
+              <h2 className={`text-xs font-semibold uppercase tracking-wide text-text-secondary${!synthesisStageDone ? " animate-pulse" : ""}`}>
+                {breadcrumbState.sLabel}
+              </h2>
+              {synthesisFinal && (
+                <button
+                  type="button"
+                  onClick={downloadFinalAnswerTxt}
+                  className="text-xs text-[#555555] hover:text-text-secondary transition-colors focus:outline-none"
+                  aria-label="Save final answer as text file"
+                >
+                  save
+                </button>
+              )}
+            </div>
             <div className="space-y-4">
               {synthesisThinking && !synthesisFinal && !String(synthesisText).trim() && (
                 <ThinkingDotsBubble
@@ -889,28 +904,25 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                   complete={synthesisFinal}
                 />
               )}
-              {/* Session notes — only when there are noteworthy annotations */}
-              {sessionComplete && annotations.length > 0 && (
-                <div className="rounded-lg border border-border bg-[#161616]" style={{ borderLeft: "3px solid #2a2a2a" }}>
-                  <button
-                    type="button"
-                    onClick={() => setAnnotationsOpen((o) => !o)}
-                    className="flex w-full items-center gap-2 px-4 py-3 text-left text-xs text-text-secondary transition-colors hover:text-text-primary focus:outline-none"
-                    aria-expanded={annotationsOpen}
-                  >
-                    <span aria-hidden style={{ display: "inline-block", transform: annotationsOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: "transform 0.15s" }}>▾</span>
-                    Session notes
-                  </button>
-                  {annotationsOpen && (
-                    <ul className="space-y-1.5 px-4 pb-4 pt-1">
-                      {annotations.map((a, i) => (
-                        <li key={i} className="flex gap-2 text-xs leading-relaxed text-text-secondary">
-                          <span className="shrink-0 text-[#444444]">·</span>
-                          <span>{a}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+              {/* Sources — citations from Perplexity fact-check */}
+              {sessionComplete && citations.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-text-secondary">Sources</p>
+                  <ol className="space-y-1">
+                    {citations.map((url, i) => (
+                      <li key={i} className="flex gap-2 text-xs text-[#888888]">
+                        <span className="shrink-0 text-[#555555]">[{i + 1}]</span>
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="break-all hover:text-text-secondary transition-colors"
+                        >
+                          {url}
+                        </a>
+                      </li>
+                    ))}
+                  </ol>
                 </div>
               )}
             </div>
@@ -1063,9 +1075,6 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
           </p>
         )}
 
-        {sessionComplete && (
-          <TakeFurther sessionConfig={sessionConfig} transcript={transcriptForExport} />
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -727,7 +727,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     // SYNTHESIS — active during observations + synthesis thinking/streaming, done when final
     const sDone = isResume || synthesisFinal;
     const sActive = synthesisPhaseEntered && !synthesisFinal;
-    const sLabel = synthesisThinking || synthesisStreaming ? "SYNTHESIZING..." : "SYNTHESIS";
+    const sLabel = synthesisThinking || synthesisStreaming ? "SYNTHESIZING..." : "FINAL ANSWER";
 
     return { promptDone, transcriptDone, transcriptActive, factDone, factActive, sDone, sActive, sLabel };
   }, [isResume, sessionStarted, synthesisPhaseEntered, perplexityPhase, synthesisThinking, synthesisStreaming, synthesisFinal]);

--- a/frontend/src/components/SynthesisPanel.jsx
+++ b/frontend/src/components/SynthesisPanel.jsx
@@ -18,31 +18,28 @@ import remarkGfm from "remark-gfm";
  */
 function SynthesisPanel({ content, isStreaming, complete }) {
   return (
-    <section aria-label="Synthesis" className="border-t border-accent-ui pt-6">
-      <h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-secondary">SYNTHESIS</h2>
-      <div className="flex max-h-[400px] w-full flex-col overflow-hidden rounded-lg border border-border bg-surface px-4 py-3" style={{ borderLeft: "3px solid #E8712A" }}>
-        <div className="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-claude">
-          Claude + Chair
-          <span className="font-normal text-text-secondary"> · final deliverable</span>
-        </div>
-        <div className="synthesis-panel-scroll min-h-0 flex-1">
-          <div className="markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
-            {isStreaming && !complete ? (
-              <span
-                className="ml-0.5 inline-block h-[1em] w-2 animate-pulse align-[-0.125em] bg-claude"
-                aria-hidden
-              />
-            ) : null}
-            {complete ? (
-              <span className="ml-2 text-xs text-text-secondary" aria-label="Complete">
-                ✓
-              </span>
-            ) : null}
-          </div>
+    <div className="flex max-h-[400px] w-full flex-col overflow-hidden rounded-lg border border-border bg-surface px-4 py-3" style={{ borderLeft: "3px solid #E8712A" }}>
+      <div className="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-claude">
+        Claude + Chair
+        <span className="font-normal text-text-secondary"> · final deliverable</span>
+      </div>
+      <div className="synthesis-panel-scroll min-h-0 flex-1">
+        <div className="markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          {isStreaming && !complete ? (
+            <span
+              className="ml-0.5 inline-block h-[1em] w-2 animate-pulse align-[-0.125em] bg-claude"
+              aria-hidden
+            />
+          ) : null}
+          {complete ? (
+            <span className="ml-2 text-xs text-text-secondary" aria-label="Complete">
+              ✓
+            </span>
+          ) : null}
         </div>
       </div>
-    </section>
+    </div>
   );
 }
 

--- a/frontend/src/components/SynthesisPanel.jsx
+++ b/frontend/src/components/SynthesisPanel.jsx
@@ -20,8 +20,8 @@ function SynthesisPanel({ content, isStreaming, complete }) {
   return (
     <div className="flex max-h-[400px] w-full flex-col overflow-hidden rounded-lg border border-border bg-surface px-4 py-3" style={{ borderLeft: "3px solid #E8712A" }}>
       <div className="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-claude">
-        Claude + Chair
-        <span className="font-normal text-text-secondary"> · final deliverable</span>
+        CLAUDE
+        <span className="font-normal text-text-secondary"> - Synthesis</span>
       </div>
       <div className="synthesis-panel-scroll min-h-0 flex-1">
         <div className="markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary">

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -35,7 +35,7 @@ function Header({ onHome, onSaveExit, children }) {
             className="w-24 shrink-0 text-right text-sm font-medium uppercase tracking-wide transition-colors hover:underline focus:outline-none"
             style={{ color: "#F5A623" }}
           >
-            Save & Exit
+            Save Session
           </button>
         ) : (
           <div className="w-24 shrink-0" aria-hidden />

--- a/frontend/src/components/common/ModelBubble.jsx
+++ b/frontend/src/components/common/ModelBubble.jsx
@@ -18,8 +18,9 @@ export { MODEL_HEX };
  * @param {boolean} [props.complete] — show subtle ✓ after model_complete
  * @param {string} [props.subtitle] — e.g. "Synthesis"
  * @param {string} [props.titleOverride] — full header line (replaces sender · subtitle)
+ * @param {string} [props.contentMaxHeight] — override inner content max-height (default "320px")
  */
-function ModelBubble({ sender, content, isStreaming, round, complete, subtitle, titleOverride }) {
+function ModelBubble({ sender, content, isStreaming, round, complete, subtitle, titleOverride, contentMaxHeight }) {
   const hex = MODEL_HEX[sender] || "#e8e8e8";
 
   return (
@@ -45,7 +46,7 @@ function ModelBubble({ sender, content, isStreaming, round, complete, subtitle, 
           </span>
         ) : null}
       </div>
-      <div className="bubble-scroll max-h-[320px] markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary">
+      <div className="bubble-scroll markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary" style={{ maxHeight: contentMaxHeight || "320px" }}>
         <ReactMarkdown>{content}</ReactMarkdown>
         {isStreaming ? (
           <span

--- a/tests/test_gemini_intake.py
+++ b/tests/test_gemini_intake.py
@@ -104,16 +104,16 @@ def test_clarification_answer_completes_session():
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Tier is "smart" or "deep" (both valid, "quick" is not)
+# Test 4: Tier is always "smart" — "deep" and "quick" are not valid literals
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("tier", ["smart", "deep"])
-def test_tier_is_valid_literal(tier):
-    decision = _decision(tier=tier)
+def test_tier_is_always_smart():
+    """Intake always returns smart — tier is Literal["smart"]."""
+    decision = _decision(tier="smart")
     with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=decision):
         session = IntakeSession()
         result = session.analyze("Test prompt")
-    assert result["config"]["tier"] == tier
+    assert result["config"]["tier"] == "smart"
 
 
 def test_invalid_tier_raises_validation_error():
@@ -128,7 +128,7 @@ def test_invalid_tier_raises_validation_error():
 
 
 def test_quick_tier_is_invalid_for_intake():
-    """quick is not a valid IntakeDecision tier — only smart and deep."""
+    """quick is not a valid IntakeDecision tier — only smart is valid."""
     with pytest.raises(ValidationError):
         IntakeDecision(
             needs_clarification=False,
@@ -139,51 +139,35 @@ def test_quick_tier_is_invalid_for_intake():
         )
 
 
-def test_deep_tier_is_valid_for_intake():
-    """Intake now assigns deep for high-stakes questions — deep is a valid literal."""
-    decision = IntakeDecision(
-        needs_clarification=False,
-        optimized_prompt="Design the data architecture for a real-time fraud detection system",
-        tier="deep",
-        output_type="decision",
-        reasoning="Deep selected — architecture decision with significant real-time constraints",
-    )
-    assert decision.tier == "deep"
+def test_deep_tier_is_invalid_for_intake():
+    """Intake always returns smart — deep is not a valid IntakeDecision tier."""
+    with pytest.raises(ValidationError):
+        IntakeDecision(
+            needs_clarification=False,
+            optimized_prompt="Design the data architecture for a real-time fraud detection system",
+            tier="deep",
+            output_type="decision",
+            reasoning="Deep selected — architecture decision",
+        )
 
 
-def test_deep_assignment_is_honoured_in_session_config():
-    """When intake assigns deep, the session config must reflect tier='deep'."""
-    deep_decision = _decision(
-        tier="deep",
-        output_type="decision",
-        reasoning="Deep selected — architecture decision",
-        optimized_prompt="Design the architecture for a real-time fraud detection system",
-    )
-    with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=deep_decision):
-        session = IntakeSession()
-        result = session.analyze("Design the architecture for a real-time fraud detection system")
-
-    assert result["config"]["tier"] == "deep"
-
-
-def test_architecture_prompt_maps_to_deep_tier():
-    """Architecture decision prompts should receive deep tier from intake.
-    This verifies the session pipeline honours deep assignment from intake."""
+def test_architecture_prompt_maps_to_smart_tier():
+    """Architecture prompts receive smart tier from intake — user upgrades via slider if needed."""
     arch_decision = _decision(
-        tier="deep",
+        tier="smart",
         output_type="decision",
-        reasoning="Deep selected — architecture decision requiring comprehensive analysis",
+        reasoning="Smart selected — architecture analysis with well-defined scope",
         optimized_prompt="Design the architecture for a real-time data processing pipeline",
     )
     with patch("backend.models.openai_client.call_gpt4o_mini_intake", return_value=arch_decision):
         session = IntakeSession()
         result = session.analyze("Design the architecture for a real-time data processing pipeline")
 
-    assert result["config"]["tier"] == "deep"
+    assert result["config"]["tier"] == "smart"
 
 
 def test_comparison_prompt_maps_to_smart_tier():
-    """Comparison prompts (X vs Y) should receive smart tier — standard analysis."""
+    """Comparison prompts (X vs Y) receive smart tier — standard analysis."""
     comparison_decision = _decision(
         tier="smart",
         output_type="comparison",

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -163,39 +163,46 @@ class TestFactcheckTokenLimits:
         assert get_factcheck_max_tokens("deep") == 2000
 
 
-# ── Intake tier assignment ────────────────────────────────────────────────────
+# ── Intake tier lock (always smart) ──────────────────────────────────────────
 
 class TestIntakeTierAssignment:
-    def test_intake_system_prompt_assigns_smart_or_deep(self):
-        """Intake now assigns smart OR deep based on prompt complexity."""
+    def test_intake_system_prompt_states_always_smart(self):
+        """Intake system prompt must instruct the model to always return smart."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
-        assert '"smart" | "deep"' in prompt or '"smart" or "deep"' in prompt or "smart" in prompt and "deep" in prompt
+        assert "always return" in prompt.lower() and "smart" in prompt
 
-    def test_intake_system_prompt_conservative_deep_rule(self):
-        """Intake system prompt must instruct the model to be conservative with deep."""
+    def test_intake_system_prompt_user_controls_tier(self):
+        """Intake system prompt must state that the user controls tier via the session UI."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
-        assert "Be conservative" in prompt
-        assert "When in doubt, assign smart" in prompt
+        assert "user controls tier" in prompt.lower() or "session ui" in prompt.lower()
 
-    def test_intake_system_prompt_deep_criteria_includes_architecture(self):
-        """Intake system prompt must include architecture decisions as deep criteria."""
+    def test_intake_system_prompt_no_deep_tier_option(self):
+        """Intake system prompt must not offer deep as a tier option."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
-        assert "Architecture decision" in prompt or "architecture" in prompt.lower()
-
-    def test_intake_system_prompt_no_downgrade_rule_present(self):
-        """Intake system prompt must state that deep cannot be downgraded."""
-        from backend.models.openai_client import _build_intake_system_prompt
-        prompt = _build_intake_system_prompt()
-        assert "cannot downgrade" in prompt or "deep runs" in prompt
+        # "deep" must not appear as a tier choice (may appear in output_type examples)
+        assert '"deep"' not in prompt and "'deep'" not in prompt
 
     def test_intake_system_prompt_no_quick_tier(self):
         """Intake system prompt must not reference quick tier as an option."""
         from backend.models.openai_client import _build_intake_system_prompt
         prompt = _build_intake_system_prompt()
         assert "quick" not in prompt.lower()
+
+    def test_intake_decision_tier_literal_is_smart_only(self):
+        """IntakeDecision.tier must be Literal["smart"] — deep is invalid."""
+        from backend.models.intake_decision import IntakeDecision
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            IntakeDecision(
+                needs_clarification=False,
+                optimized_prompt="Test",
+                tier="deep",
+                output_type="analysis",
+                reasoning="test",
+            )
 
 
 # ── Validator safety ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Complete UX overhaul plus architecture fixes from April 19, 2026.

## Architecture
- Factcheck always deep (2000 tokens) regardless of session tier
- Intake always assigns smart — user controls Deep via slider
- IntakeDecision.tier locked to Literal["smart"]

## UX
- PROMPT fixed at top, active stage below, completed stages scroll
- FINAL ANSWER auto-expanded as primary output
- OPTIMIZED PROMPT bubble — scrollable, correct label
- FACT-CHECK — scrollable bubble, no fold toggle
- RESEARCH — four independent scrollable bubbles, alphabetical
- Smart/Deep one-directional slider — Smart default, upgrades to Deep, locks
- SAVE SESSION button downloads full session .md
- SAVE link next to FINAL ANSWER downloads synthesis as .txt
- Citations list below synthesis card
- Session notes removed
- "Take this further" section removed
- Breadcrumb renamed SYNTHESIS → FINAL ANSWER

## Tests
- 183+ passing