### PR TITLE
docs(transcripts): add transcripts 013-017 + clean stray file + update README index

### DIFF
--- a/docs/transcripts/013-isone-offshore-wind-four-model-round1-alt.md
+++ b/docs/transcripts/013-isone-offshore-wind-four-model-round1-alt.md
@@ -1,0 +1,125 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*Summary · quick · April 17, 2026*
+
+---
+
+## Opening Prompt
+
+Provide a concise summary of ISO New England's current capacity accreditation methodology specifically for offshore wind resources.
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+## Round 1: Claude
+
+ISO New England's capacity accreditation for offshore wind uses a marginal reliability impact methodology that differs significantly from traditional capacity valuation approaches.
+
+[LIKELY] The current framework, implemented around 2023-2024, calculates offshore wind's capacity contribution based on its **marginal Effective Load Carrying Capability (ELCC)**. This measures how much additional offshore wind capacity reduces the probability of capacity shortfalls during peak reliability hours, rather than using simplistic capacity factors or nameplate ratings.
+
+[VERIFIED] Key features include:
+
+1. **Performance during reliability hours**: The methodology focuses on wind output during the system's most stressed periods — typically summer peak demand hours in ISO-NE's case, though winter reliability events are increasingly relevant.
+
+2. **Declining marginal value**: As more offshore wind connects to the grid, each incremental MW provides diminishing capacity value due to correlation in wind patterns across nearby offshore sites.
+
+3. **Seasonal and hourly granularity**: The analysis examines historical wind patterns during specific reliability windows rather than annual averages.
+
+[UNCERTAIN] Current accreditation values for offshore wind in ISO-NE likely range between 15-35% of nameplate capacity, though this varies by project location, vintage of analysis, and total offshore wind penetration assumed. Early projects may receive higher values than later ones due to the marginal decline effect.
+
+[DEFER] For the most current numerical values and any 2024 methodology updates, ISO-NE's Forward Capacity Auction (FCA) qualification materials would be authoritative — my training data may not reflect their latest filings.
+
+The methodology represents a more sophisticated approach than simple capacity factor calculations, recognizing both the reliability value and limitations of variable renewable resources.
+
+### 🟢 GPT
+
+[DEFER] I don't have detailed, up-to-date information on ISO New England's current capacity accreditation methodology for offshore wind resources. To get the most accurate and current information, it would be best to consult ISO New England's official publications or recent announcements on their website. Their documents typically outline methodologies and any recent changes or proposals related to capacity accreditation.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+### Audit of AI Model Responses vs. Current Web Research
+
+#### 1. Facts that are Outdated or Incorrect per Current Web Research
+- **Gemini's response**: Unavailable (skipped after retries); no facts to audit[all sources].
+- **GPT's response**: 
+  - States lack of "detailed, up-to-date information" on the methodology, which is incorrect—ISO-NE's RCA framework under Capacity Auction Reforms (CAR) uses a **Marginal Reliability Impact (MRI)** approach for offshore wind, implemented in phases with specifics documented as of 2024[3][4][7][8].
+  - Recommends consulting ISO-NE's website without specifics, but research shows the methodology treats offshore wind similarly to onshore (class-average **rMRI** due to limited data/privacy), with Phase 1 live by Sept 2024 for FCA 19[3][4][7][8].
+  - No mention of key distinctions like seasonal QMRICs or criticisms; this defers unnecessarily as details exist in ISO-NE filings (e.g., Feb/May 2024 memos)[7][8].
+
+No dates in GPT response contradict research; last updates reference Sept 3, 2025 MRI memo (no changes since Oct 2025)[live research].
+
+#### 2. Important Current Information Neither Model Mentioned
+- **MRI Framework Details**: Offshore wind (>10 MW) uses probability-weighted expected performance in stress hours, with class-average rMRI lower than onshore due to seasonal QCs/performance factors; no distinction from onshore to protect privacy[3][7][8].
+- **Implementation Phases**:
+  | Phase | Description | Timeline |
+  |-------|-------------|----------|
+  | Phase 1 | Challenge tech type/winter capability; values reported to owners | Implemented by Sept 2024 for FCA 19[4] |
+  | Phase 2 | ISO calculates individual FCA QMRICs for high-need hours | Post-Phase 1[4] |
+- **Criticisms**: Undervalues offshore wind (higher capacity factors) vs. overvaluing gas (ignores outages); builds on ELCC shift for clean energy[1][2][5][7][8].
+- **No Recent Changes**: Sept 3, 2025 memo latest; stable since Oct 2025[3][4][7][8].
+- **Historical Shift**: From ELCC to MRI for intermittency in wind/solar[2][5][6].
+
+#### 3. Tools or Courses that Have Changed in Relevance Recently
+- No tools, frameworks, or courses mentioned in research or live summary.
+- **Unchanged Relevance**: DNV process for synthetic profiles (wind/solar ≥10 MW) remains standard from 2024 docs; no updates in last 6 months[2][9].
+- **No New Tools**: RCA modeling uses historical/synthetic profiles; ISO-NE economist video (undated) overviews but adds no tools[10].
+- Research gaps: No practitioner tools/blogs on Reddit/Hacker News/LinkedIn; no job/salary data[ live research].
+
+#### 4. What the Current Practitioner Community Actually Recommends Right Now
+- **No Direct Practitioner Discussions**: Search results lack Reddit/Hacker News/LinkedIn posts, blogs, or salary trends; only official ISO-NE docs (2022-2025) and one NRDC critique[1][3][4][7][8][live research].
+- **Implied Recommendations from Sources**:
+  - ISO-NE stakeholders: Adopt MRI for FCA 19 (2028/2029 period) to value intermittency/reliability[3][4][6][7].
+  - Critics (e.g., NRDC): Distinguish offshore wind reliability, account for gas outages in RCA[1].
+- **Community Consensus**: Use class-average rMRI; no offshore/onshore split due to data limits[7][8]. No hiring/job market recs; consult ISO-NE filings for latest[3][4].
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+[VERIFIED] ISO-NE currently accredits offshore wind capacity using a **Marginal Reliability Impact (MRI)** methodology implemented under its Capacity Auction Reforms (CAR), which went live for Forward Capacity Auction 19 (covering the 2028/2029 delivery period) as of September 2024.
+
+
+The MRI framework evaluates offshore wind's contribution to grid reliability by calculating **probability-weighted expected performance during system stress hours** — the periods when the grid is most likely to experience capacity shortfalls. This replaces the older ELCC-based approach and treats intermittent resources like wind and solar with far greater granularity.
+
+[VERIFIED] For offshore wind projects over 10 MW, ISO-NE uses a **class-average relative MRI (rMRI)** value rather than project-specific assessments. Importantly, offshore wind is **not distinguished from onshore wind** in the current methodology — both receive the same class-average treatment to protect data privacy given the limited operational history of offshore projects in the region.
+
+This creates a meaningful issue: [VERIFIED] offshore wind typically demonstrates higher capacity factors and more consistent generation patterns than onshore wind, yet the methodology currently undervalues this reliability advantage. Critics, including environmental advocates like NRDC, have pointed out that the framework also overvalues gas-fired generation by not adequately accounting for forced outages during winter stress events.
+
+
+[VERIFIED] ISO-NE rolled this out in phases:
+
+**Phase 1** (completed September 2024): Resources can challenge their technology type or winter capability classification, with calculated values reported to resource owners before FCA 19.
+
+**Phase 2** (ongoing): ISO will calculate individual FCA Qualified Marginal Reliability Impact Capacity (QMRIC) values for high-need hours, providing more granular seasonal assessments.
+
+The methodology assigns **seasonal QMRICs** that reflect when offshore wind actually performs during reliability events, rather than using annual averages that obscure seasonal variability.
+
+
+[LIKELY] Based on the class-average rMRI approach and the marginal contribution framework, offshore wind in ISO-NE currently receives capacity accreditation in the range of 15-35% of nameplate capacity, though this is *not* a fixed value — it declines as more offshore wind connects to the grid due to correlation in wind patterns across geographically proximate sites.
+
+[VERIFIED] The key driver is performance during **summer peak demand hours and winter reliability events**, not annual energy production. As offshore wind penetration increases in New England, the marginal reliability value of each additional MW decreases because multiple offshore projects experience similar wind conditions simultaneously.
+
+
+The round-1 models disagreed on data availability — GPT-4o claimed insufficient current information exists, while Claude and Grok described ELCC-based approaches. [VERIFIED] Both are outdated: ISO-NE transitioned from ELCC to MRI specifically to better value intermittency and reliability contributions, and comprehensive documentation exists in ISO-NE's February and May 2024 stakeholder memos.
+
+The methodology remains stable as of the most recent September 3, 2025 memo with no changes since October 2025. However, [UNCERTAIN] there's ongoing tension in stakeholder processes about whether the class-average treatment adequately incentivizes offshore wind development, given its superior reliability characteristics compared to onshore resources.
+
+
+1. **Download ISO-NE's latest MRI documentation** from their Capacity Auction Reforms page — specifically the February/May 2024 stakeholder memos and the September 2024 Phase 1 implementation summary. These contain the actual calculation methodology and worked examples for offshore wind.
+
+2. **Request historical stress-hour performance data** from ISO-NE for existing offshore wind projects (if you're a developer or stakeholder). Understanding when your project generates during the top 10% of system stress hours directly determines your capacity value under MRI.
+
+3. **Model your project's expected QMRIC** using ISO-NE's published MRI calculator framework with synthetic wind profiles from DNV (the standard approach for projects without operational history). Run sensitivity analyses for different offshore wind penetration scenarios — your capacity value will decline as New England's offshore pipeline (currently 5+ GW in development) comes online.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/013-isone-offshore-wind-smart-tier-smoke-test.md
+++ b/docs/transcripts/013-isone-offshore-wind-smart-tier-smoke-test.md
@@ -1,0 +1,121 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*factual answer · smart · April 18, 2026*
+
+---
+
+## Opening Prompt
+
+What is ISO New England's current capacity accreditation methodology for offshore wind?
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+ISO New England has been developing capacity accreditation methodologies for offshore wind as part of broader efforts to integrate variable renewable resources into their Forward Capacity Market (FCM).
+
+**What I can say with reasonable confidence:**
+
+ISO-NE has been moving toward Marginal Reliability Impact (MRI) based accreditation for intermittent resources, which is conceptually similar to Effective Load Carrying Capability (ELCC) methods used by other grid operators. This approach measures a resource's contribution to system reliability during hours when the system is most stressed, rather than relying on simple capacity factors or nameplate ratings.
+
+For offshore wind specifically, this matters because New England's reliability challenges increasingly center on winter peaks driven by cold weather events—periods when wind conditions can be highly variable. The methodology likely accounts for the correlation (or lack thereof) between offshore wind generation patterns and these critical system stress periods.
+
+**Important caveats:**
+
+1. My training data has a cutoff date, and ISO-NE's capacity market rules have been actively evolving through ongoing stakeholder processes
+2. ISO-NE has been conducting significant reforms to resource capacity accreditation (RCA) that may have changed specific parameters, implementation timelines, or methodological details since my knowledge was last updated
+3. The treatment of offshore wind may differ from onshore wind given different production profiles and the fact that major offshore projects are still ramping up in the region
+
+**For authoritative current information:**
+
+Consult ISO-NE's tariff documents, the Resource Capacity Accreditation project page, or recent Installed Capacity Working Group materials available on their website. FERC filings related to FCM rule changes would also contain definitive methodology details.
+
+### 🔵 Gemini
+
+ISO New England (ISO-NE) accredits the capacity of intermittent resources, including offshore wind, using a probabilistic methodology known as the Marginal Reliability Impact (MRI) approach. This is a specific implementation of an Expected Peak Load Carrying Capability (EPLCC) model. The goal is to calculate a resource's "Qualified Capacity" (QC), which represents its effective contribution to system reliability for participation in the Forward Capacity Market (FCM).
+
+The methodology involves the following key steps:
+
+1.  **Identify System Reliability Hours:** The MRI model first identifies the specific hours of the year when the electric grid is under the most stress and at the greatest risk of a capacity shortfall. These "high-risk" hours are determined by calculating the system's loss of load expectation (LOLE).
+
+2.  **Analyze Performance During Critical Hours:** The model then assesses the expected power output of the offshore wind facility specifically during these identified high-risk hours. A resource that reliably generates power when the system needs it most receives a higher capacity value.
+
+3.  **Utilize Long-Term Data:** For new offshore wind projects without operational history, the analysis relies on long-term (typically 20+ years) simulated meteorological and oceanographic data for the specific project location. This data is converted into an hourly power production profile using the wind turbine's technical specifications and power curve. For existing resources, historical operational data is used.
+
+4.  **Account for Correlation and Diversity:** The QC value is highly dependent on the correlation between the offshore wind farm's output and system needs during reliability hours. The methodology inherently captures the diversity benefit of offshore wind, whose generation profile (often stronger in winter and evening hours) is different from other intermittent resources like solar.
+
+This probabilistic approach differs significantly from how dispatchable resources like natural gas or nuclear plants are accredited. Those resources are typically assigned a capacity value based on their demonstrated maximum output, adjusted for historical forced outage rates (Seasonal Claimed Capability).
+
+The precise models, input data assumptions, and parameters for the MRI calculation are subject to ongoing review and refinement through ISO-NE's stakeholder processes to ensure accuracy as the regional resource mix evolves.
+
+### 🟢 GPT
+
+I do not have the latest details on ISO New England's specific capacity accreditation methodology for offshore wind. However, generally, ISO New England evaluates energy resources, like offshore wind, using probabilistic analyses and historical performance data to estimate their capacity contributions. For the most accurate and up-to-date information, it is recommended to consult ISO New England's official publications or their website.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+# Fact-Check Audit: ISO New England Offshore Wind Capacity Accreditation
+
+## Accuracy Assessment
+
+**Gemini's response contains significant inaccuracies:**
+
+The claim that ISO-NE uses a "Marginal Reliability Impact (MRI) approach" as "a specific implementation of an Expected Peak Load Carrying Capability (EPLCC) model" is **misleading**. According to search results, ISO-NE has been moving toward a **marginal Resource Adjusted Availability (RAA) model**, not MRI/EPLCC as distinct methodologies[7]. The pre-research context clarifies that ISO-NE is "shifting from prior Effective Load Carrying Capability (ELCC) to better reflect resource diversity," indicating ELCC was the prior standard, not the current EPLCC implementation Gemini describes[1].
+
+Gemini's detailed description of "Loss of Load Expectation (LOLE)" calculations and "Seasonal Claimed Capability" for dispatchable resources, while conceptually sound, **cannot be verified against the search results provided** and may reflect outdated or generic grid methodology rather than ISO-NE's current framework.
+
+**GPT's response is appropriately cautious** and acknowledges knowledge limitations, avoiding specific claims that could be inaccurate.
+
+**Grok's response is partially accurate but dated.** It correctly identifies ELCC as ISO-NE's historical approach but notes a 2023 knowledge cutoff. However, it fails to mention the newer RAA marginal methodology now under stakeholder review for FCA 19 implementation[1][4].
+
+**Claude's response is the most reliable.** It correctly identifies the shift toward "Marginal Reliability Impact (MRI) based accreditation" for intermittent resources and appropriately flags knowledge limitations and ongoing stakeholder processes[1]. It avoids overstating certainty and recommends consulting current tariff documents.
+
+## Top 3 Critical Missing/Outdated Information
+
+1. **Methodology Transition Not Fully Captured**: All four responses except Claude omit that ISO-NE's RCA project represents an **active shift away from ELCC to a marginal RAA model**, proposed for FCA 19 (2028/2029 delivery year) with a one-year implementation delay[1][4]. This is not merely refinement but a structural methodological change.
+
+2. **Profile Generation Process Specifics**: None address the **four-phase profile creation process**, including validation of resource-specific parameters (wind speed, turbine characteristics) and use of DNV modeling for synthetic hourly performance profiles when historical data is insufficient[1]. This is central to offshore wind accreditation.
+
+3. **Potential Undervaluation Issue**: The pre-research context notes that "onshore and offshore wind are accredited similarly without distinct adjustments for offshore's higher capacity factors, potentially undervaluing it per critics"[2]. No response addresses this policy debate or the absence of offshore-specific adjustments.
+
+## Currency Status
+
+All responses predate April 2026. Search results show the most recent substantive updates occurred in May 2024 (impact analyses and sensitivity refinements)[8][9]. **No flagged changes have occurred in the last 6 months** (October 2025–April 2026); the RCA methodology remains in stakeholder review toward FCA 19 implementation[1][4]. Gemini and Grok should be flagged as outdated; Claude and GPT are appropriately cautious but lack recent detail.
+
+## Recommendation Priority
+
+**High-impact correction**: Gemini
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+ISO New England (ISO-NE) is currently transitioning its capacity accreditation methodology for offshore wind towards a "marginal Resource Adjusted Availability (RAA)" model. This represents a structural change from the previous Effective Load Carrying Capability (ELCC) approach. The aim is to better reflect the diverse contributions of different types of resources to system reliability, especially in light of New England's specific grid reliability challenges which often occur during winter peaks when wind conditions can be variable.
+
+1. [VERIFIED] **Transition to RAA Model:** ISO-NE is moving away from the ELCC approach to a marginal RAA model. This change is part of the Resource Capacity Accreditation (RCA) project proposed for implementation in the Forward Capacity Auction (FCA) 19, targeting the 2028/2029 delivery year[1].
+
+2. [VERIFIED] **Profile Generation Process:** The methodology involves a detailed, four-phase process to create generation profiles for wind resources. This process includes validating resource-specific parameters, leveraging modeling to develop synthetic hourly performance profiles when historical data is lacking[1].
+
+3. [VERIFIED] **Potential Undervaluation Issue:** Critics have noted that onshore and offshore wind is currently accredited similarly without distinct adjustments for the higher capacity factors observed in offshore wind, which could potentially lead to undervaluation[2].
+
+- [VERIFIED] Perplexity's research confirms the shift toward an RAA model, contradicting Gemini's claim that ISO-NE uses a Marginal Reliability Impact (MRI) approach as part of an Expected Peak Load Carrying Capability (EPLCC) model, which now appears outdated.
+
+1. **Review ISO-NE Tariff Documents:** To understand detailed current methodologies, reviewing ISO-NE's official tariff documents and the Resource Capacity Accreditation project page would provide authoritative insights.
+
+2. **Monitor Stakeholder Updates:** Staying informed on stakeholder reviews and updates through the Installed Capacity Working Group or other ISO-NE meeting materials will provide the latest procedural developments.
+
+3. **Participate in Public Consultation:** Engaging in public consultations or submitting feedback during stakeholder processes could be valuable, especially concerning the treatment of offshore wind and potential undervaluation concerns.
+
+By taking these steps, one can stay ahead in the evolving landscape of renewable energy accreditation within New England.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/014-isone-offshore-wind-deep-tier-validation.md
+++ b/docs/transcripts/014-isone-offshore-wind-deep-tier-validation.md
@@ -1,0 +1,141 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*factual answer · deep · April 19, 2026*
+
+---
+
+## Opening Prompt
+
+What is ISO New England's current capacity accreditation methodology for offshore wind?
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+ISO New England's capacity accreditation methodology for offshore wind is an evolving area that I need to address carefully given the regulatory complexity involved.
+
+[LIKELY] ISO-NE has been transitioning away from traditional capacity accreditation approaches toward methodologies that better reflect the reliability contribution of intermittent resources like offshore wind. The region has been developing what's called a "marginal reliability impact" (MRI) or similar probabilistic framework that attempts to measure how much a resource actually contributes to meeting peak demand during stressed system conditions.
+
+[UNCERTAIN] Specifically for offshore wind, ISO-NE has been grappling with how to assign capacity values given that:
+1. The region has limited operational history with large-scale offshore wind
+2. Offshore wind generation profiles differ significantly from onshore wind (typically higher capacity factors, different diurnal patterns)
+3. There's correlation risk during winter peak events when multiple offshore facilities might see reduced output simultaneously
+
+[LIKELY] The methodology likely involves an Effective Load Carrying Capability (ELCC) approach or a variant thereof, which calculates what fraction of nameplate capacity can be reliably counted toward meeting reserve margins. For offshore wind, early estimates have suggested ELCC values in the range of 20-40% of nameplate, though this is highly sensitive to assumptions about fleet diversity and weather correlation.
+
+[DEFER] For the precise current methodology—including any recent tariff changes, specific capacity values being applied in Forward Capacity Auctions, or updates from NEPOOL stakeholder processes—I'd recommend checking ISO-NE's official documentation or recent FERC filings, as this has been actively debated and may have evolved beyond my training data.
+
+What aspects of the accreditation approach are most relevant to your inquiry?
+
+### 🔵 Gemini
+
+The premise of your question—that there is a single, stable "current" methodology—is the first thing we should challenge. ISO New England is in the midst of a fundamental, multi-year shift away from a simplistic historical performance model to a more complex probabilistic one. Therefore, the "current" answer is one of transition.
+
+The new framework, broadly known as Resource Capacity Accreditation (RCA), is moving all resources, including offshore wind, to a methodology based on **Marginal Reliability Impact (MRI)**. This is conceptually identical to what other grid operators call Effective Load Carrying Capability (ELCC).
+
+Here’s the breakdown of this transition:
+
+1.  **The Legacy Method (Being Phased Out):** For years, a new renewable resource's initial capacity value was based on a marginal analysis, but its ongoing qualification was tied to its measured performance during a specific, limited set of peak hours. This was a backward-looking, empirical calculation that was criticized for failing to capture the diminishing reliability returns as more of a single type of intermittent resource is added to the grid.
+
+2.  **The New Method (Being Phased In):** The MRI approach is a forward-looking, probabilistic model. It doesn't ask "How did this resource perform during last year's five peak hours?" Instead, it asks, "If we add this specific offshore wind project to the grid of the future, how much additional load can the entire system reliably serve?"
+
+The core logic of MRI is this:
+*   The model runs thousands of simulations of a future year, accounting for variable weather, generator outages, and fluctuating demand.
+*   It calculates the system's overall reliability (e.g., the risk of a shortfall) *without* the new wind farm.
+*   It then adds the wind farm to the model and calculates how much more load would need to be added to the system to return to the *exact same* level of reliability risk as before.
+*   That amount of added load is the "Effective Capacity" or accredited capacity of the wind farm.
+
+[LIKELY] This MRI-based methodology has been approved by FERC and is being implemented over a series of Forward Capacity Auctions (FCAs). For offshore wind, the initial capacity values for projects entering the queue are now determined using this probabilistic approach.
+
+The crucial implication, and the reason for the change, is that MRI captures **correlated performance**. The first gigawatt of offshore wind may have a high capacity credit because its output is often uncorrelated with other system risks. However, the tenth gigawatt, whose output will be highly correlated with the first nine, will have a progressively lower marginal reliability impact and therefore receive a lower capacity accreditation value. The system doesn't gain the same reliability benefit from the 10th unit as it did from the 1st.
+
+So, to directly answer your question: ISO New England's current methodology for offshore wind accreditation is a transition to a fully probabilistic, Marginal Reliability Impact model. The specific values are not static; they are the output of a complex model that will be re-run for future auctions and will change as the resource mix on the New England grid evolves.
+
+### 🟢 GPT
+
+[DEFER] I don't have access to the most current details on ISO New England's capacity accreditation methodology for offshore wind. ISO New England typically reviews and updates its methodologies periodically. For the most up-to-date and accurate information, I recommend reviewing ISO New England's official reports or contacting them directly.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+### 1. Verification of EVERY Specific Factual Claim
+
+I systematically verified each distinct factual claim (including named entities, dates, statistics, methodologies, timelines, and implications) from all four Round-1 responses against the Pre-Research Context and provided Search Results [1-10]. Claims are quoted verbatim where possible, followed by accuracy assessment, correction if needed, supporting citation(s), and my confidence level (High: directly confirmed by multiple sources; Medium: confirmed by Pre-Research or single source with context; Low: inferred or unconfirmed).
+
+#### gemini Claims
+- "ISO New England is in the midst of a fundamental, multi-year shift away from a simplistic historical performance model to a more complex probabilistic one." **Accurate.** Matches Pre-Research Context on RCA transition from legacy empirical methods to probabilistic MRI[1][7][9]. *Confidence: High.*
+- "The new framework, broadly known as Resource Capacity Accreditation (RCA), is moving all resources, including offshore wind, to a methodology based on **Marginal Reliability Impact (MRI)**." **Accurate.** RCA uses MRI (equivalent to ELCC marginal approach) for all resources including offshore wind[1][4][5]. *Confidence: High.*
+- "This is conceptually identical to what other grid operators call Effective Load Carrying Capability (ELCC)." **Accurate.** Pre-Research explicitly notes RCA builds on ELCC with marginal approach[1][4][5]. *Confidence: High.*
+- "For years, a new renewable resource's initial capacity value was based on a marginal analysis, but its ongoing qualification was tied to its measured performance during a specific, limited set of peak hours." **Accurate.** Describes legacy method phased out in RCA[1]. *Confidence: Medium.*
+- "The MRI approach... runs thousands of simulations of a future year, accounting for variable weather, generator outages, and fluctuating demand." **Accurate.** Core logic of probabilistic MRI in RCA[1][7][9]. *Confidence: High.*
+- "It calculates the system's overall reliability (e.g., the risk of a shortfall) *without* the new wind farm... adds the wind farm... how much more load would need to be added to... return to the *exact same* level of reliability risk... That amount... is the 'Effective Capacity'." **Accurate.** Precise description of MRI calculation process[1]. *Confidence: High.*
+- "This MRI-based methodology has been approved by FERC and is being implemented over a series of Forward Capacity Auctions (FCAs)." **Partially accurate but outdated.** RCA/MRI proposed for FCA 19 (2026 auction, 2028-2029 delivery), to be filed with FERC by late 2025; not yet fully approved/implemented as of Apr 2026[1][4][5]. No FERC approval confirmed in results. *Confidence: Medium.*
+- "For offshore wind, the initial capacity values for projects entering the queue are now determined using this probabilistic approach." **Inaccurate.** New offshore wind uses synthetic profiles via DNV process (Phase 1 of RCA), not yet fully probabilistic MRI for accreditation; proposed for FCA 19[1][7][9]. *Confidence: High.*
+- "MRI captures **correlated performance**. The first gigawatt... high capacity credit... the tenth gigawatt... highly correlated... lower marginal reliability impact." **Accurate.** Explicit purpose of MRI to account for diminishing returns from correlation[1][2][6]. *Confidence: High.*
+- "ISO New England's current methodology... is a transition to a fully probabilistic, Marginal Reliability Impact model. The specific values are not static; they are... re-run for future auctions." **Accurate.** RCA is transitional, model re-run iteratively[1][8][9]. *Confidence: High.*
+
+#### gpt Claims
+- "ISO New England typically reviews and updates its methodologies periodically." **Accurate.** Iterative updates via NEPOOL/stakeholder processes[1][8]. *Confidence: High.*
+- No other specific claims; response defers. **N/A.**
+
+#### grok Claims
+- "ISO-NE historically uses a methodology tied to Effective Load Carrying Capability (ELCC), which assesses a resource’s contribution... by modeling its output during peak load conditions and high-risk periods." **Accurate.** RCA builds on ELCC[1][4][5]. *Confidence: High.*
+- "For offshore wind, this would account for seasonal wind patterns, historical performance data (if available), and correlation with system demand." **Accurate.** Profiles incorporate these via historical/synthetic data[1][7][9]. *Confidence: High.*
+- "Offshore wind... higher capacity factors, especially in the Northeast." **Accurate.** Pre-Research notes higher capacity factors vs. onshore, better winter performance[2][6]. *Confidence: Medium.*
+- "ISO-NE might assign a higher capacity credit to offshore wind compared to onshore—potentially in the range of 30-40% of nameplate capacity—based on studies from similar regions like PJM or NYISO." **Unconfirmed statistic.** Pre-Research mentions early estimates 20-40% (Claude), but no ISO-NE specific confirmation; criticized for uniform wind treatment[2][6]. Not in search results. *Confidence: Low.*
+- "many offshore projects in the New England (e.g., Vineyard Wind) are still ramping up and lack long-term operational history." **Accurate.** Limited history drives synthetic profiles[1][7]. *Confidence: Medium.*
+- "ISO-NE’s grid is increasingly stressed by winter peaks due to electrification of heating and transportation. Offshore wind’s output often peaks in colder months." **Accurate.** Aligns with Pre-Research on winter performance[2][6]. *Confidence: Medium.*
+- No confirmation of FERC approval or exact ISO-NE values. **N/A.**
+
+#### claude Claims
+- "ISO-NE has been transitioning... toward... 'marginal reliability impact' (MRI) or similar probabilistic framework." **Accurate.** RCA/MRI transition[1][4][5]. *Confidence: High.*
+- "The region has limited operational history with large-scale offshore wind." **Accurate.** <5 years data uses blends/synthetics[1][7][9]. *Confidence: High.*
+- "Offshore wind generation profiles differ significantly from onshore wind (typically higher capacity factors, different diurnal patterns)." **Accurate.** Pre-Research/advocacy notes[2][6]. *Confidence: Medium.*
+- "There's correlation risk during winter peak events when multiple offshore facilities might see reduced output simultaneously." **Accurate.** MRI addresses this[1][2]. *Confidence: High.*
+- "The methodology likely involves an Effective Load Carrying Capability (ELCC) approach or a variant... calculates what fraction of nameplate capacity can be reliably counted." **Accurate.** RCA/ELCC variant[1][4][5]. *Confidence: High.*
+- "For offshore wind, early estimates have suggested ELCC values in the range of 20-40% of nameplate." **Partially accurate.** Matches Pre-Research early estimates, but no firm ISO-NE values; uniform treatment criticized[2][6]. *Confidence: Medium.*
+- "Proposed for FCA 19 (2026 auction, procuring for 2028-2029 delivery year), with a one-year delay option. Filed with FERC by late 2025" [from Pre-Research, echoed]. **Accurate.** Exact match[1][4][5]. *Confidence: High.*
+
+### 2. Mapping Contradictions Between Models
+
+| Contradiction | Models Involved | Correct Version | Reason and Citation |
+|---------------|-----------------|-----------------|---------------------|
+| FERC approval status of MRI/RCA | gemini: "approved by FERC and... implemented over FCAs." | Incorrect (gemini). Others defer/avoid claim. | RCA proposed for FCA 19, FERC filing by late 2025; no approval confirmed as of Apr 2026[1][4][5]. Pre-Research stable since Feb 2024, no recent change[8][9]. |
+| Current application to offshore wind queues | gemini: "initial capacity values... now determined using this probabilistic approach." | Incorrect (gemini). grok/claude: historical/transitioning (accurate). | Synthetic DNV profiles for new offshore (Phase 1), full MRI for FCA 19 (2026+); not "now" implemented[1][7][9]. |
+| Capacity value ranges | grok: "30-40%"; claude: "20-40%". | Neither fully confirmed; claude closer. | Early estimates 20-40%, but no official ISO-NE values; uniform wind treatment ongoing[2][6]. grok speculates from PJM/NYISO. |
+| Implementation timeline | gemini: "over a series of FCAs" (vague). claude/Pre-Research: FCA 19 specific. | claude/Pre-Research correct. | Explicitly FCA 19 (2028-2029 delivery)[1][4][5]. |
+| Legacy method details | gemini: peak hours performance. gr
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+ISO New England is in the process of transitioning its capacity accreditation methodology for offshore wind from a legacy empirical approach to a more sophisticated probabilistic framework called the Resource Capacity Accreditation (RCA). This new framework is based on Marginal Reliability Impact (MRI), which is conceptually similar to the Effective Load Carrying Capability (ELCC) used by other grid operators [VERIFIED][1][4][5].
+
+- **Legacy Method**: Historically, ISO-NE determined the capacity value of renewables based on performance during peak hours. This method was criticized for not adequately capturing the diminishing returns of adding more intermittent resources to the grid.
+- **MRI-Based Methodology**: The transition to MRI involves running thousands of simulations to predict how additional resources (like offshore wind) affect the overall system reliability. It calculates how much additional load the system can handle while maintaining a consistent level of reliability risk [VERIFIED][1][9].
+
+- **Current Status**: The RCA initiative incorporating MRI is currently being phased in and has been proposed for implementation in the 2026 Forward Capacity Auction (FCA 19), with delivery projected for the 2028-2029 capacity year [VERIFIED][1][4][5]. Contrary to some reports, it has not yet received full FERC approval as of April 2026.
+- **Offshore Wind Specifics**: Currently, the methodology for new offshore wind projects involves using synthetic profiles from a process developed with DNV, rather than a fully probabilistic MRI approach. The full incorporation of MRI for all resources, including offshore wind, is planned for future implementation [VERIFIED][1][7][9].
+
+- **Higher Capacity Factors**: Offshore wind projects generally have higher capacity factors, especially in the Northeast, compared to onshore projects [LIKELY][2][6].
+- **Time Sensitivity and Correlation**: MRI captures the correlated performance of similar resources, making capacity values dynamic and sensitive to factors like weather patterns and the existing fleet [VERIFIED][1][6].
+
+The current transition reflects a significant methodological shift that aims to provide a more accurate and dynamic assessment of resource reliability contributions. While the method promises more adaptability, the lack of full implementation and FERC approval indicates ongoing refinement is needed. It is crucial for stakeholders to stay informed through updates from ISO-NE as methodologies evolve to meet regional decarbonization goals effectively.
+
+1. **Monitor ISO-NE Updates**: Stay updated with ISO-NE's announcements and reports, especially regarding RCA progress and changes to capacity accreditation processes.
+2. **Engage with Stakeholder Processes**: Participate in NEPOOL stakeholder meetings to gain insights and influence the development of these methodologies.
+3. **Review FERC Filings**: Keep an eye on FERC filings related to these methodologies to understand any regulatory changes that may impact implementation timelines and resource planning.
+
+This response incorporates current, verified insights from live research, contrasting misinformation found in some round-1 models.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/015-mcp-agentic-workflows-2026.md
+++ b/docs/transcripts/015-mcp-agentic-workflows-2026.md
@@ -1,0 +1,364 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*analysis · smart · April 19, 2026*
+
+---
+
+## Opening Prompt
+
+What should a serious AI product engineer know about the current state of MCP and agentic workflows in 2026, focusing on technical details and practical implementation? Specifically, how do MCP servers integrate with coding tools like GitHub Copilot and Claude Code, and what agentic workflow patterns are emerging in production?
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+## MCP and Agentic Workflows in 2026: What AI Product Engineers Need to Know
+
+### The Model Context Protocol (MCP)
+
+MCP is Anthropic's open specification for standardizing how AI systems access external resources—tools, data sources, and services. It addresses ecosystem fragmentation: before MCP, every AI product built bespoke integrations for file systems, databases, and APIs. MCP provides a universal interface layer.
+
+**Core Technical Architecture**
+
+The architecture involves MCP servers that expose three capability types:
+- **Tools**: Executable functions (run tests, query database, create PR)
+- **Resources**: Data the model can read (files, documentation, schemas)
+- **Prompts**: Templated interactions for common workflows
+
+Communication happens over a transport layer—stdio for local processes, HTTP with Server-Sent Events (SSE) for remote connections. Clients (Claude Desktop, Claude Code, custom agents) connect to servers and discover capabilities via a handshake protocol. The server advertises what's available; the client decides what to invoke.
+
+The protocol uses JSON-RPC 2.0 for message formatting, with defined methods for initialization, capability discovery, and invocation.
+
+### Integration with Coding Tools
+
+**Claude Code**
+
+Claude Code is Anthropic's agentic coding tool that runs in the terminal. MCP integration is native—you configure servers in your settings, and Claude Code can invoke their capabilities during coding sessions. Typical server configurations for coding workflows include:
+- File system servers for repository access
+- Git servers for version control operations
+- Database servers for schema introspection
+- Build/test servers for CI feedback loops
+
+The agent queries these servers to ground responses in real project state rather than hallucinating file paths or outdated dependencies.
+
+**GitHub Copilot**
+
+GitHub Copilot uses its own extension architecture rather than MCP natively. Integration approaches include:
+- Building bridge layers that translate MCP server capabilities into Copilot extension formats
+- Running MCP servers alongside Copilot and using orchestration layers that can call both
+- Using VS Code extensions that speak to MCP servers and surface results to Copilot's context
+
+The interoperability story is still maturing—no standard bridge protocol has emerged. For teams committed to MCP, Claude Code offers tighter integration; for Copilot-centric workflows, expect custom middleware.
+
+### Agentic Workflow Patterns in Production
+
+**1. Tool-Use Loops with Human Checkpoints**
+
+Agent proposes a change via MCP tool call, surfaces a diff or preview, and waits for approval before execution. This addresses the runaway agent problem. Implementation pattern:
+```
+Agent → MCP Server (preview mode) → Return diff → Human approval → MCP Server (execute mode) → Confirm result
+```
+
+**2. Contextual Resource Injection**
+
+Instead of dumping entire repositories into context, agents query MCP servers for relevant snippets based on task. Example: "I need the database schema for the `users` table" returns just that DDL, not the entire migration history. This requires smart retrieval logic in servers—semantic search, dependency tracing, or explicit scope parameters.
+
+**3. Stateful Multi-Turn Tasks**
+
+MCP servers maintain session state for partially completed work (e.g., a refactor across multiple files). The agent can pause, resume, or backtrack without losing progress. Implementation requires:
+- Session identifiers passed with each request
+- Server-side transaction semantics or journaling
+- Rollback capabilities for failed operations
+
+**4. Composition of Specialized Servers**
+
+One MCP server for git operations, another for test execution, a third for cloud infrastructure. The agent routes requests based on intent. Disambiguation is the hard part—when the user says "deploy this," the agent must determine which server handles it. Solutions include:
+- Explicit tool namespacing (`git.commit`, `infra.deploy`)
+- Agent-side intent classification before routing
+- Server metadata describing domain boundaries
+
+**5. Evaluation-Driven Development**
+
+Agents run code, observe test results via MCP servers, and iterate. The pattern: generate → test → analyze failures → refine → repeat. This requires MCP servers that return structured test output (not just pass/fail, but failure reasons, stack traces, coverage data) that agents can reason about.
+
+### Practical Implementation Considerations
+
+**Authentication and Secrets Management**
+
+MCP servers need credentials for databases, APIs, and cloud services. Approaches:
+- Environment variables injected at server startup
+- Integration with credential stores (HashiCorp Vault, AWS Secrets Manager)
+- OAuth flows for user-scoped permissions
+- Credential isolation—secrets never enter LLM context, only results
+
+**Error Handling**
+
+If an MCP tool call fails, agents need structured error responses they can reason about. Design errors with:
+- Error codes agents can match against
+- Human-readable messages for surfacing to users
+- Suggested remediation actions
+- Retry eligibility indicators
+
+**Rate Limiting and Cost Control**
+
+MCP servers can invoke expensive operations. Guardrails include:
+- Request budgets per session or time window
+- Cost estimation endpoints agents can check before expensive calls
+- Circuit breakers that halt runaway loops
+- Tiered approval gates for high-cost operations
+
+**Observability**
+
+Log every MCP call with inputs, outputs, latency, and caller context. When agents misbehave, you need the audit trail. Structured logging should capture:
+- Session/conversation ID for request correlation
+- Tool name and parameters
+- Response payload (or hash for large responses)
+- Execution duration and resource consumption
+
+**Versioning and Schema Evolution**
+
+If an MCP server updates its tool signatures, existing agents may break. Mitigation strategies:
+- Semantic versioning for server capabilities
+- Capability negotiation during handshake
+- Deprecation periods with dual-support
+- Client-side compatibility layers
+
+### Production Recommendations
+
+1. **Start with read-only servers** (resources and prompts) before adding mutating tools. Easier to reason about safety and debug issues.
+
+2. **Design for failure**: Assume tools will timeout, return partial data, or reject requests. Agent prompts should include explicit fallback strategies.
+
+3. **Implement preview modes**: Every state-changing tool should have a dry-run option that returns what *would* happen.
+
+4. **Don't over-index on autonomy**: The most reliable agentic workflows still have humans at decision points. MCP makes it easier to surface those decision points cleanly.
+
+5. **Test with adversarial inputs**: Agents will eventually send malformed requests, hit edge cases, or attempt operations outside their intended scope. Servers need defensive validation.
+
+6. **Plan for context limits**: MCP makes it easy to pull lots of data—agents must be selective. Build servers that support filtering, pagination, and relevance scoring.
+
+### Current Ecosystem State
+
+The MCP ecosystem includes:
+- Official reference servers from Anthropic (filesystem, git, database connectors)
+- Community-built servers for popular services (Slack, Jira, various databases)
+- Framework support in LangChain, LlamaIndex, and similar orchestration libraries
+- IDE integrations beyond Claude Code emerging from the community
+
+For the latest on specific integrations, check Anthropic's MCP documentation, the MCP GitHub repository, and community registries. The ecosystem is evolving rapidly, with new servers and patterns emerging regularly.
+
+### 🔵 Gemini
+
+By 2026, the concept of a monolithic "MCP (Multi-Agent Coordination Protocol) Server" will be obsolete. Instead, a serious AI product engineer must think in terms of designing and managing a **Multi-Agent Coordination Plane**: a distributed, resilient, and observable set of services that form the backbone of an agentic system. The primary challenge has shifted from prompt engineering to architecting production-grade systems that are reliable, secure, and cost-effective.
+
+Here is what a serious AI product engineer must know, focusing on technical reality and implementation.
+
+### 1. The Core Architecture of the Multi-Agent Coordination Plane
+
+The coordination plane is not a single application but a distributed architecture comprising four distinct layers. Your role is to select, configure, and integrate components for each layer based on trade-offs between latency, cost, and complexity.
+
+**A. The Communication Layer: Asynchronous vs. Synchronous**
+This is the nervous system for inter-agent communication. The key architectural decision is choosing between asynchronous messaging and direct synchronous calls.
+
+*   **Asynchronous (Dominant Pattern):** Built on durable message queues like **Kafka**, **RabbitMQ**, or cloud services like **AWS SQS/SNS**.
+    *   **Technical Details:** Agents publish messages (e.g., `TaskAssigned`, `ResultReady`, `ToolFailed`) to specific topics. Other agents subscribe to these topics. This decouples agents, allowing them to operate independently and scale separately. It provides resilience; if a consumer agent is down, the message waits in the queue.
+    *   **Practical Implementation:** You will define strict, versioned message schemas (using Protobuf or Avro) to ensure compatibility. You'll need to manage dead-letter queues for failed message processing and implement idempotency in consumer agents to handle message replays. This pattern is ideal for workflows that can tolerate moderate latency but require high reliability.
+
+*   **Synchronous (For Tight-Loop Operations):** Uses direct RPC frameworks like **gRPC** or REST APIs for low-latency, request/response interactions.
+    *   **Technical Details:** An orchestrator agent makes a blocking call to a specialized agent (e.g., a "Code Execution Agent") and waits for the result.
+    *   **Practical Implementation:** Best for tightly-coupled tasks like a "Proposer" agent asking a "Validator" agent to review its output before proceeding. The primary challenge is managing cascading failures and timeouts. Circuit breaker patterns are essential here.
+
+**B. The State & Memory Layer: From Context to World Models**
+Agents require a shared understanding of the world and the current task. This is managed through a multi-tiered state management system.
+
+*   **Short-Term Task Context:** Stored in high-speed, low-latency key-value stores like **Redis**. This holds ephemeral data for a single, in-flight operation: the current task graph, intermediate results, and session-specific information.
+*   **Long-Term Agent Memory:** Managed in **Vector Databases** (e.g., Pinecone, Weaviate). When an agent needs to recall past interactions or relevant knowledge, it performs semantic searches against this store. The core challenge is designing an effective retrieval and synthesis strategy to avoid polluting the context window.
+*   **Shared World Model:** For complex systems, a shared, canonical representation of the operational environment is stored in a document DB (**MongoDB**) or graph DB (**Neo4j**). For example, a software development system might maintain a graph of the entire codebase, which agents can query and update. The key challenge is concurrency control and preventing race conditions when multiple agents attempt to modify the state simultaneously.
+
+**C. The Orchestration & Planning Layer: Declarative Workflows**
+This layer determines which agent does what, and when. The trend is moving from imperative, hard-coded logic to declarative frameworks.
+
+*   **Technical Details:** Instead of writing Python code that says "call Agent A, then Agent B," you define the workflow in a declarative format (often YAML or a DSL). Frameworks like **LangGraph** or advanced versions of **CrewAI** allow you to define agents as nodes and transitions as edges in a state graph. The engine then executes the graph, handling cycles (for iteration/reflection), branching, and state transitions.
+*   **Practical Implementation:** Your job is to design these graphs. You'll define the available agents as tools, the rules for transitioning between them (e.g., "if validation fails, transition to the `Refinement` node"), and how shared state is passed. This simplifies debugging and allows for dynamic plan modification.
+
+**D. The Execution & Tooling Layer: Secure and Sandboxed**
+This is where agents interact with the outside world (APIs, databases, filesystems). It must be the most secure part of the system.
+
+*   **Technical Details:** Agents do not call external tools directly. They make requests to a centralized **Tool Abstraction Gateway**. This service is responsible for:
+    *   **Authentication & Authorization:** Securely managing and injecting API keys and credentials.
+    *   **Sandboxing:** Executing potentially unsafe code (e.g., Python scripts generated by an agent) in an isolated environment using technologies like **Firecracker MicroVMs** or **WebAssembly (WASM)**.
+    *   **Rate Limiting & Caching:** Preventing agents from overwhelming external APIs and caching results from idempotent tool calls to reduce cost and latency.
+*   **Practical Implementation:** You will define tools using a strict schema (e.g., OpenAPI spec) and register them with the gateway. Agents are granted specific permissions on a per-tool, per-task basis, enforcing the principle of least privilege.
+
+### 2. Integration with Coding Tools: The Rise of Agentic DevOps
+
+GitHub Copilot and Claude Code are not just for writing individual agent logic; they are becoming essential for managing the entire agentic system lifecycle.
+
+*   **Orchestration Co-Architecting:** These tools help you write the declarative workflow configurations (e.g., LangGraph schemas), suggest optimal agent compositions for a given task, and generate the Protobuf/Avro schemas for inter-agent communication. You describe the desired workflow, and they scaffold the complete configuration.
+*   **Agent Evals as Unit Tests:** A critical emerging practice is "evaluation-driven development." You create a "golden dataset" of inputs and desired outcomes. Copilot/Claude helps you write test harnesses that run your agent or multi-agent system against this dataset, asserting that the final output meets quality, safety, and formatting standards. These evals become part of your CI/CD pipeline.
+*   **Debugging and Observability:** When a workflow fails, you will feed the execution trace (from tools like LangSmith, Arize, or OpenTelemetry traces) into a model like Claude. It will analyze the sequence of agent interactions, LLM inputs/outputs, and tool calls to pinpoint the root cause of failure and suggest fixes to the orchestration graph or agent prompts.
+
+### 3. Production-Ready Agentic Workflow Patterns
+
+By 2026, successful production systems will rely on robust, repeatable patterns that balance autonomy with control.
+
+*   **Hierarchical Planner-Worker:** A high-level `Planner` agent decomposes a complex request into a task graph. It then dispatches these sub-tasks to specialized `Worker` agents (e.g., `CodeWriter`, `APICaller`, `DataAnalyzer`). The Planner monitors progress, re-assigning or retrying failed tasks. This is the dominant pattern for complex, multi-step operations.
+*   **Multi-Agent Debate & Refinement (Critic-Proposer):** For tasks requiring high quality, one agent (`Proposer`) generates a solution (e.g., a block of code, a marketing email). A second `Critic` agent, often using a different LLM or a more critical prompt, reviews the solution against a predefined rubric or set of constraints. If it finds flaws, the output is sent back to the Proposer with feedback for refinement. This iterative loop continues until the Critic approves the work.
+*   **Human-in-the-Loop (HILO) Supervision:** This is not just a fallback but a core feature. The system is designed to route specific events to a human for approval or intervention.
+    *   **Approval Gates:** Before executing a high-stakes action (e.g., deploying code, sending a mass email), the agent must request human approval. The UI presents a clear summary of the proposed action and its likely impact.
+    *   **Ambiguity Resolution:** When an agent's confidence score for a decision is below a set threshold, or when it faces a novel problem, it automatically flags the situation for a human collaborator, providing its analysis and a set of possible options.
+
+The AI product engineer of 2026 is a distributed systems architect who orchestrates non-deterministic, intelligent components. Your focus will be less on perfecting a single prompt and more on designing a resilient, observable, and secure coordination plane that delivers reliable outcomes.
+
+### 🟢 GPT
+
+As of 2026, an AI product engineer focused on MCP (Model-Controlled Processes) and agentic workflows should be thoroughly familiar with the following technical details and practical implementation strategies:
+
+1. **MCP Integration with Coding Tools**:
+   - **Integration with GitHub Copilot and Claude Code**: These tools use advanced deep learning models, such as Codex. MCP servers can enhance functionality by centralizing model management, deployment, and version control. Integration is achieved through robust APIs that allow seamless interaction within Integrated Development Environments (IDEs) where these tools operate.
+   - **Practical Implementation**: Develop APIs facilitating plugin development for IDEs to incorporate MCP features like centralized dashboards for model access control, updates, and permissions, ensuring a unified experience across diverse coding environments.
+
+2. **Emerging Agentic Workflow Patterns in Production**:
+   - **Modular and Interoperable AI Agents**: Modular agent design is advancing, allowing distinct AI functions to be combined flexibly across tasks with interoperability facilitated by standardized integration protocols.
+   - **Event-Driven Architectures**: Asynchronous workflows where agents react to dynamic triggers (e.g., real-time data changes or user interactions) are gaining traction, enhancing automation's responsiveness and scalability.
+   - **Human-in-the-Loop Systems**: Critical workflows continue to incorporate human oversight to ensure reliability, especially where sensitivity or ethical implications are involved. Enhanced frameworks are emerging for integrated decision-making and validation processes.
+
+3. **Technical Considerations for Robust Integration**:
+   - **Security**: Implement comprehensive security protocols to safeguard model integrity and data privacy, especially in collaborative platforms like GitHub.
+   - **Scalability and Performance Optimization**: Develop systems capable of handling extensive concurrent user interactions with AI models, optimizing for latency and resource allocation.
+   - **Interoperability and Compatibility**: Ensure MCP systems support diverse programming languages and frameworks, facilitating integration into various coding environments and extending the utility of coding tools like GitHub Copilot and Claude Code.
+
+To ensure you are up-to-date with the latest practices and developments, engage with current technical documentation from platform providers and scholarly research. Networking with industry peers engaged in cutting-edge projects can also provide deeper insights into practical strategies and innovations.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+# Fact-Check Audit: AI Agent Protocol Responses for April 2026
+
+## 1. Critical Errors and Outdated Claims
+
+**Gemini's Response: Fundamentally Mischaracterizes MCP's 2026 Role**
+
+Gemini treats MCP as "obsolete" by 2026 and reframes the entire discussion around a "Multi-Agent Coordination Plane" with four custom layers (communication, state, orchestration, execution). This is **contradicted by current ecosystem reality**.[1][3]
+
+The factual error: **MCP remains the dominant agent-to-tool protocol with 97 million downloads**[3] and has achieved "cross-vendor adoption" that "happened faster than any previous developer protocol in the AI space."[3] Rather than becoming obsolete, MCP has evolved into the standard foundation. The 2026 roadmap explicitly shifts MCP toward "agent-to-agent communication" and "distributed coordination,"[1] not away from relevance.
+
+Gemini's proposed architecture (Kafka, Redis, Neo4j, custom orchestration graphs) describes *enterprise infrastructure layers above MCP*, not replacements for it. This conflates two different abstraction levels and gives engineers a misleading mental model that MCP is outdated when it's actually foundational.
+
+**GPT's Response: Vague and Lacks Current Protocol Context**
+
+GPT mentions "MCP (Model-Controlled Processes)" without clarifying that **MCP stands for Model Context Protocol**[1] and misses the 2026 ecosystem entirely. It discusses "modular agents" and "event-driven architectures" generically without addressing:
+- The emergence of **four complementary protocols by Q1 2026: MCP, A2A, ACP, and UCP**[3]
+- MCP's specific role as the agent-to-tool layer[3]
+- A2A (Agent-to-Agent) as the coordination layer that handles multi-agent delegation[3]
+
+This response reads as pre-2026 material, offering no insight into the protocol stack that has "emerged with meaningful industry adoption."[3]
+
+**Grok's Response: Appropriately Transparent but Outdated**
+
+Grok explicitly flags uncertainty about 2026 specifics and defers to current sources—a honest approach, but the response is essentially non-actionable for a 2026 context. It extrapolates from 2023 trends without incorporating the actual 2026 ecosystem (MCP's governance shift to Linux Foundation in December 2025,[1] the standardization of async/HITL operations,[1] and the four-protocol stack).[3]
+
+**Claude's Response: Accurate and Aligned with Current Reality**
+
+Claude correctly identifies MCP as "Anthropic's open specification for standardizing how AI systems access external resources"[Claude response], understands the JSON-RPC 2.0 foundation,[Claude response] and accurately describes MCP's integration with Claude Code.[Claude response] However, it predates recent developments:
+- **MCP governance moved to the Linux Foundation in December 2025**, but Claude's response does not mention this.[1]
+- **Agent-to-Agent (A2A) coordination is now the complement to MCP** for multi-agent workflows, not a speculative future pattern.[3]
+- **MCP Tasks, Tool Annotations, and Audio Support** have shipped as of 2026, but Claude describes these as forward-looking.[1]
+
+---
+
+## 2. Top 3 Missing Critical Information
+
+### A. The Four-Protocol Stack is Now Standard (Q1 2026)
+**What's missing:** All four responses underweight the ecosystem coherence that emerged by Q1 2026. The production stack is:
+- **MCP** for agent-to-tool access (97M downloads, cross-vendor)[3]
+- **A2A (Agent-to-Agent)** for multi-agent delegation and coordination (50+ launch partners, rollout since Q3 2025)[3]
+- **ACP/UCP** for commerce transactions (niche, enterprise-specific)[3]
+
+This is **not speculative**—sources explicitly state "four protocols have emerged with meaningful industry adoption" as of Q1 2026, and "the protocols are complementary, not competing."[3] Engineers who design only MCP integrations or treat A2A as aspirational are misaligned with production reality.
+
+### B. Governance Maturation and Enterprise Readiness Are Core to 2026
+**What's missing:** All responses underemphasize that **governance moved from application code to the protocol layer**.[1] The 2026 roadmap explicitly calls out:
+- **Transport layer identity and policy enforcement** (not just prompts)[1]
+- **Observability and audit requirements** at the protocol level[1]
+- **Linux Foundation governance** (as of Dec 2025) enabling enterprise standardization[1]
+
+This is critical for production engineers: tools like **Tool Annotations (readOnly/destructive flags) trigger human-in-the-loop warnings automatically**,[1] not via custom application logic. Responses that focus on custom orchestration miss this shift.
+
+### C. Async/HITL Operations and Agent Tasks Are Now Production-Ready
+**What's missing:** **MCP Tasks for long-lived background operations** (data migrations, batch processing) and **native HITL (human-in-the-loop) patterns** are now core to the 2026 spec.[1] This enables:
+- Agents to queue work that survives disconnections
+- Mid-task human approvals without re-prompting
+- Resumable workflows with dynamic policies[1]
+
+Gemini and GPT discuss HITL generically without noting that **MCP has standardized these patterns at the protocol level**, not leaving them to application-layer implementation. Claude hints at this but doesn't foreground it.
+
+---
+
+## 3. Accuracy Assessment by Response
+
+| Response | Core Accuracy | Currency (Apr 2026) | Actionability |
+|----------|---------------|-------------------|---------------|
+| **Gemini** | ❌ Fundamentally wrong (MCP not obsolete) | ❌ Outdated framing | ❌ Misleading |
+| **GPT** | ⚠️ Vague but not wrong | ❌ Pre-ecosystem awareness | ⚠️ Generic, weak |
+| **Grok** | ✅ Honest uncertainty | ⚠️ Defers to 2023 trends | ❌ Not actionable |
+| **Claude** | ✅ Accurate on MCP basics | ⚠️ Predates governance shift | ✅ Mostly applicable |
+
+---
+
+## 4. Top Corrections and Recommendations
+
+**For Gemini:**
+Discard the framing that MCP is obsolete. Replace with: **MCP is the foundational agent-to-tool protocol in 2026, with 97 million downloads and cross-vendor adoption.**[3] Custom orchestration layers (Kafka, Redis, etc.) sit *above* MCP, not replace it. The 2026 roadmap evolves MCP toward peer-to-peer agent communication, not away from it.[1]
+
+**For GPT:**
+Add protocol-stack awareness: Clarify that **MCP handles agent-to-tool access; A2A handles agent-to-agent coordination.**[3] Mention the **governance shift to the Linux Foundation** and the maturation of **Tool Annotations and async task support**.[1] These are not emerging—they are production-ready as of April 2026.
+
+**For Grok:**
+Acknowledge current information sources (e.g., search results published Feb–Apr 2026) explicitly in the response, rather than deferring entirely. Flag the **four-protocol ecosystem** as the definitive Q1 2026 development.[3]
+
+**For Claude:**
+Add: (1) **MCP governance moved to Linux Foundation in Dec 2025**, enabling broader enterprise adoption;[1] (2) **A2A is the standard complement for multi-agent workflows, not a future consideration**;[3] (3) **MCP Tasks and Tool Annotations are production-ready**, shifting HITL and async operations from custom code to protocol primitives.[1]
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+Regarding the state of MCP (Model Context Protocol) and agentic workflows in 2026, there are several critical insights and technical details that a serious AI product engineer should be aware of. Here’s a synthesis, primarily based on [VERIFIED] live research, augmented by analysis of round-1 responses:
+
+
+1. **MCP’s Prominence**: Contrary to prior claims of obsolescence, [VERIFIED] MCP remains a dominant protocol in the AI space with over 97 million downloads, serving as the foundational protocol for agent-to-tool interactions. It continues to evolve as the standard model for AI systems accessing external resources.
+2. **Ecosystem Role**: MCP is central to a broader ecosystem of four complementary protocols as of Q1 2026—MCP for agent-to-tool access, A2A for agent-to-agent coordination, and others for commerce transactions. This was not effectively captured in some older model analyses.
+3. **Governance and Maturity**: As of December 2025, MCP’s governance was shifted to the Linux Foundation, facilitating greater enterprise standardization and readiness.
+
+
+1. **With Claude Code**: MCP integrates natively, leveraging its architecture to invoke capabilities during coding. Claude Code can access git, file systems, databases, and CI services directly through MCP servers, grounding responses in real project states.
+2. **With GitHub Copilot**: While there is no native implementation of MCP with Copilot, integration could be achieved via custom middleware or bridge layers translating MCP functionalities into a form usable by Copilot extensions.
+
+
+1. **Tool-Use Loops with Human Checkpoints**: This pattern involves agents using MCP to queue actions that require human approval, thus preventing rogue automation.
+2. **Contextual Resource Injection**: Agents query MCP for specific data segments rather than entire repositories, optimizing memory usage and contextual relevance.
+3. **Stateful Multi-Turn Tasks**: Ongoing interactions that MCP servers can handle include maintaining state across multiple sessions, allowing for operation pause, resume, or rollback features for enhanced task management.
+
+
+- **Gemini's Claims**: Suggested MCP was outdated, replaced by new architectures with Kafka, Redis, which was **contradicted** by [VERIFIED] sources stating MCP's continued significance and cross-vendor adoption.
+- **Grok's Uncertainty**: Highlighted a lack of specific information on MCP, correctly deferring to newer data sources for 2026 context.
+- **Claude's Outdatedness**: Provided accurate protocol basics but didn't account for the 2025 governance shift or newer patterns like A2A.
+
+
+1. **Update Protocol Implementations**: Ensure that development practices are aligned with MCP’s expansive role within the four-protocol stack and its Linux Foundation governance.
+2. **Experiment With MCP Integration**: If using Claude Code, leverage its native MCP capabilities to enhance agentic coding tools. For GitHub Copilot, explore middleware solutions that facilitate MCP connectivity.
+3. **Adopt Emerging Workflows**: Incorporate stateful task management and human checkpoints into production environments, leveraging MCP for enhanced control and coordination.
+
+In sum, MCP remains a critical component of AI systems in 2026, integrated deeply into the broader stack of agentic workflows and interfacing with tools like Claude Code, albeit less seamlessly with others like GitHub Copilot. For a serious AI product engineer, aligning with these developments and integrating these patterns into their systems will be crucial for maintaining cutting-edge practices.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/016-open-source-vs-private-portfolio.md
+++ b/docs/transcripts/016-open-source-vs-private-portfolio.md
@@ -1,0 +1,314 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*analysis · smart · April 19, 2026*
+
+---
+
+## Opening Prompt
+
+What are the trade-offs of building AI portfolio projects as open source versus keeping them private for someone targeting AI Product Engineer roles at frontier AI companies?
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+# Open Source vs. Private AI Portfolio Projects for Frontier AI Product Engineering Roles
+
+The conventional wisdom says "open source everything to show your work" — but that's incomplete advice for AI product engineering roles at frontier labs. The calculation is more nuanced than many candidates realize.
+
+## The Open Source Case
+
+Frontier labs actively monitor their own open source ecosystems. Anthropic watches Claude API builders. OpenAI tracks developers pushing boundaries with their tools. The best portfolio projects don't just demonstrate competence — they demonstrate **taste in problem selection**. 
+
+What matters: Can you identify a real friction point in the current API surface? Can you build something developers actually want to use? The signal isn't "I made another chatbot" — it's "I found a novel way to handle context window management that people actually adopted."
+
+Open source also forces better engineering discipline. You can't ship hacky code when others will read it. You write better docs. You think about API design. You handle edge cases. These are table stakes for product engineering, not nice-to-haves.
+
+**Additional benefits:**
+- Creates networking opportunities when others engage with your work
+- Demonstrates communication skills through issues, PRs, and documentation
+- Shows you can handle public feedback and iterate based on it
+
+## The Private Repository Trap
+
+Here's where candidates miscalculate: they keep projects private to "protect their ideas" or maintain "competitive advantage." 
+
+Frontier AI companies are not hiring you for your idea. They have more ideas than engineers to build them. They're hiring you for execution speed, taste, and ability to navigate ambiguity. A private repo signals none of those things.
+
+Valid reasons to keep something private:
+- Working with proprietary or customer data
+- Under NDA or contractual obligations
+- Commercially sensitive work from actual employment
+- Security-sensitive implementations (auth systems, vulnerability research)
+
+If your reasoning is "someone might copy this" — you're optimizing for the wrong variable.
+
+## The Hybrid Strategy
+
+The strongest candidates often do this:
+
+**Open source the framework, keep the application-specific elements private.**
+
+Example: You build an evaluation harness for comparing model performance on domain-specific tasks. Open source the harness architecture, the benchmark design, the comparison methodology. Keep private: any proprietary prompts you're testing for clients, customer data, specific production configurations tied to paying users.
+
+This lets you demonstrate:
+- System design thinking (the framework is public)
+- Real-world constraint handling (the private app proves you've shipped)
+- Judgment about what to share versus protect
+
+## What Actually Gets You Interviews
+
+The meta-skill frontier labs screen for: **Can you build useful things with LLMs despite how fast everything changes?**
+
+Your portfolio should answer:
+- Have you shipped something people use (even a small user base counts)
+- Can you evaluate quality systematically (not just subjective impressions)
+- Do you understand current limitations from hands-on experience
+- Can you make pragmatic trade-offs under uncertainty
+
+A single well-documented open source project with genuine community engagement and a technical writeup will typically outperform multiple private repos you can only describe in bullet points. Hiring managers can verify open source work directly; private projects require trust.
+
+## Contributing to Existing Projects
+
+One underrated approach: contribute meaningfully to an established open source AI project rather than only building from scratch. A merged PR to widely-used tools or a frontier lab's own repositories can signal capabilities that standalone projects cannot. It proves you can:
+- Navigate existing codebases
+- Take feedback constructively
+- Collaborate with maintainers
+- Add value within constraints you didn't set
+
+This complements rather than replaces original projects — ideally you demonstrate both.
+
+## The Core Trade-off
+
+The real tension isn't "open vs. closed" — it's "legible signal vs. illegible signal." Open source is the highest-bandwidth way to make your work verifiable to people who don't know you yet.
+
+However, recognize the costs: maintaining open source takes time, handling issues and questions takes energy, and not every project benefits from being public. The strategic question is which projects maximize signal for the roles you're targeting, not whether to open source everything indiscriminately.
+
+### 🔵 Gemini
+
+For an AI Product Engineer targeting a frontier AI company, a portfolio is not just a collection of code; it's a strategic narrative proving you can bridge state-of-the-art AI with real-world product value. The choice between open-source and private projects isn't binary—it's about curating evidence for the specific capabilities these elite companies seek.
+
+Here’s a breakdown of the trade-offs and the optimal strategy.
+
+---
+
+### The Case for Open-Source Projects
+
+Open-source projects provide undeniable, public proof of your technical and collaborative skills.
+
+**Key Signals Sent:**
+
+1.  **Engineering Rigor & Production Readiness:** Public code is unforgiving. It forces you to write clean, documented, tested, and maintainable code. This signals that you can contribute to a large, high-stakes codebase from day one, a non-negotiable skill for shipping products at a frontier lab.
+2.  **Collaboration and Communication:** A successful open-source project, even a small one, demonstrates your ability to articulate a problem, design a solution for others, and engage with a community through issues, pull requests, and documentation. This directly maps to the cross-functional communication required in a Product Engineer role.
+3.  **Identifying and Solving a Real Need:** If your tool or library gains traction (even a few dozen stars or a handful of users), it's powerful evidence of "product sense." You identified a genuine pain point for a user (often other developers), built a solution, and successfully delivered value.
+
+**When to Use Open Source:** To showcase foundational software engineering skills, your ability to build a useful tool, and your understanding of the developer ecosystem.
+
+---
+
+### The Case for Private Projects
+
+Private projects allow you to demonstrate ambition, product vision, and the ability to build a complete, opinionated application.
+
+**Key Signals Sent:**
+
+1.  **End-to-End Product Vision:** A private project lets you go beyond a library and build a full-fledged application. You can demonstrate skills in user experience, application design, and creating a polished demo. This shows you think about the entire user journey, not just the underlying model.
+2.  **Novelty and IP Exploration:** Frontier companies value unique insights. A private project lets you explore a novel application of a foundation model, use a proprietary dataset, or test a unique fine-tuning strategy without revealing your "secret sauce." The focus shifts from the *code* to the *idea* and its execution.
+3.  **Rapid, Focused Prototyping:** Without the overhead of public maintenance, you can iterate quickly, take risks, and focus purely on achieving a compelling outcome. This mimics the high-velocity "0 to 1" product development cycles common within frontier AI companies.
+
+**When to Use Private Projects:** To showcase an ambitious product idea, demonstrate skills with the latest models in a complete application, and tell a compelling story about solving a user problem.
+
+---
+
+### The Optimal Strategy: The "1-2 Punch" Hybrid Portfolio
+
+The most effective approach is a curated blend that uses each project type to its maximum advantage.
+
+**1. The Open-Source Foundation (The "Tool")**
+
+Have at least one high-quality, open-source project. This project serves as your technical bedrock.
+
+*   **What it should be:** A well-packaged tool that solves a real problem for developers working with modern AI.
+*   **Examples:** A lightweight library for evaluating RAG systems, a tool for managing complex prompt chains, a framework for testing vision model outputs, or an efficient data processing utility for fine-tuning.
+*   **How to present it:** A pristine GitHub repository with a clear `README.md` that explains the *why*, not just the *how*. Include installation instructions, usage examples, a contribution guide, and tests.
+
+**2. The Private Showcase (The "Product")**
+
+Complement your open-source tool with a more ambitious, private project that functions as a polished product demo.
+
+*   **What it should be:** A functional web app or self-contained demo that uses a frontier model (via API) to deliver a unique and compelling user experience.
+*   **Examples:** An application that uses vision and language models to generate interior design concepts from photos, a tool that creates complex, multi-step agentic workflows from natural language, or a personalized education tutor powered by a fine-tuned model.
+*   **How to present it (Crucial):** Since the code is private, your presentation is everything. Create a dedicated project page, blog post, or a section on your personal website with:
+    *   **A Killer Demo Video (Essential):** A 1-2 minute, well-edited screen recording showing the product in action and highlighting its core value.
+    *   **A Detailed Write-up:** Explain the problem you're solving, your target user, the technical architecture (with diagrams), the key challenges you faced, and the trade-offs you made.
+    *   **Product Reflections:** Discuss what you learned, what you would do next, and your thoughts on potential product-market fit.
+
+**Conclusion**
+
+Don't just choose between open-source and private. Use an **open-source tool** to prove your engineering fundamentals and community awareness. Then, use a **polished private product** to showcase your ambition, product vision, and ability to create novel, compelling experiences with cutting-edge AI. This combination provides undeniable proof of both the "Engineer" and the "Product" aspects of the role they are hiring for.
+
+### 🟢 GPT
+
+When deciding whether to build AI portfolio projects as open source or keep them private, particularly targeting AI Product Engineer roles at frontier AI companies, several trade-offs merit consideration:
+
+1. **Visibility and Networking**:
+   - **Open Source**: Open-source projects significantly enhance your visibility in the AI community. They showcase your skills to potential employers and collaborators, contributing to a robust professional reputation and offering valuable networking opportunities.
+   - **Private**: By keeping projects private, you limit exposure and miss out on the networking benefits that can come with participating in open-source communities.
+  
+2. **Intellectual Property and Competitive Advantage**:
+   - **Open Source**: Sharing projects openly can dilute your competitive advantage by making your innovations accessible to others. This may limit your ability to present these projects as unique selling points in your career.
+   - **Private**: Retaining exclusivity over your projects allows you to present novel solutions in job interviews, potentially standing out with unique concepts or innovations.
+
+3. **Feedback and Improvement**:
+   - **Open Source**: Open-source projects benefit from community feedback, which can lead to rapid improvements and facilitate collaborative learning. This engagement can lead to higher quality and more robust projects.
+   - **Private**: The absence of community input may limit the project's iterative process, potentially slowing down development and reducing the project’s refinement.
+
+4. **Speed and Freedom**:
+   - **Open Source**: Managing community contributions and adhering to open-source standards can introduce delays, shifting focus toward maintaining code quality and compliance.
+   - **Private**: Private projects allow for rapid iteration, flexibility, and prioritization of personal learning goals without outside constraints.
+
+5. **Skill Showcasing**:
+   - **Open Source**: Demonstrates your technical and collaborative abilities, essential for teamwork-focused environments in AI companies.
+   - **Private**: Emphasizes your capability to drive independent projects, illustrating your ability to take initiative and see a project through without external assistance.
+
+For an aspiring AI Product Engineer, it might be strategic to use a hybrid approach: keeping some innovative or proprietary projects private to maintain a competitive edge, while also engaging in open-source projects to gain visibility, community insight, and demonstrate teamwork skills.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+I'll fact-check these four responses against the provided search results and flag accuracy issues, outdated claims, and missing information.
+
+---
+
+## Key Findings
+
+### Critical Inaccuracies and Unsupported Claims
+
+**1. Frontier Deployment Engineer (FDE) Role Confusion**
+
+All four responses conflate "frontier AI product engineering" with "frontier deployment engineering"—a distinct role described in the search results. The search results define **Frontier Deployment Engineers** as specialists who "deploy production-ready AI features while taking into account constraints of quality, risk, & cost," focusing on translating business needs into tech specs, building AI services, setting up monitoring, and managing rollouts[1]. 
+
+**The responses incorrectly frame** open-source vs. private portfolio decisions as relevant to FDE hiring, when the search results don't address portfolio strategy for FDEs specifically. The "Gemini" and "Claude" responses especially over-generalize from "AI product engineer" (undefined in results) to frontier company hiring without grounding in the FDE role definition.
+
+**Impact:** Moderate—responses may guide candidates toward irrelevant portfolio strategies for the actual role being hired.
+
+---
+
+**2. Unsubstantiated Claims About Frontier Company Preferences**
+
+- **Claude** claims "Anthropic watches Claude API builders" and "frontier labs actively monitor open-source ecosystems"—this is inferred speculation unsupported by the search results.
+- **Grok** asserts "frontier AI companies often prioritize confidentiality" and that private portfolios signal "discretion"—this is a cultural assumption not evidenced in the results.
+- **GPT** states open-source "enhance[s] your visibility in the AI community" as fact for frontier hiring—the search results don't discuss frontier company hiring preferences for open vs. private portfolios.
+
+**Search results do mention** that "OpenAI, Anthropic, and Cohere have built frontier deployment engineer teams" and demand rose "about 800% since early 2025"[1], but provide no guidance on portfolio preferences (open vs. private).
+
+**Impact:** High—candidates may make portfolio decisions based on invented hiring signals.
+
+---
+
+**3. Misleading Claims About Frontier Model Vendors**
+
+**Grok** states: "Latest Tool/Framework Updates (Last 6 Months, ~Oct 2025-Apr 2026): Performance gap between open-source (e.g., Llama, Mistral) and proprietary (GPT-4, Claude) narrowed to **0.7% on key benchmarks by late 2025**."
+
+This is **entirely fabricated**—no benchmark data appears in the search results. The results mention "frontier models" and vendor names (OpenAI, Anthropic, Cohere) but contain zero performance comparisons or benchmark statistics[1][6].
+
+**Impact:** Critical—false technical claims undermine credibility and could mislead technical hiring decisions.
+
+---
+
+### Top 3 Missing Current Information
+
+**1. What Frontier Deployment Engineers Actually Expect in Portfolios**
+
+The search results define the FDE role extensively (responsibilities, key principles, success metrics)[1], but **none of the four responses reference FDE-specific portfolio expectations**. Search result [1] mentions that "FDEs combine full-stack development skill set with deep understanding of AI and product sense" and lists engineering tasks (API design, fallback scenarios, cost optimization, semantic caching, JSON outputs, streaming)[1]—this directly implies portfolio projects should showcase these capabilities, yet no response mentions this.
+
+**2. Real-World Portfolio Standards for AI Engineering Roles**
+
+Search result [2] states that "By 2026, recruiters are looking for **real-world solutions** that demonstrate your ability to integrate AI into broader systems" and specifies portfolio expectations by career level: beginners focus on clean implementations, intermediate developers handle "the hidden 90% of AI work - things like data cleaning, implementing guardrails, and solving deployment challenges," and senior engineers showcase "multi-agent systems, real-time data streaming, and multi-modal analysis"[2]. 
+
+**None of the four responses reference these 2026 hiring expectations or deployment-focused portfolio guidance.** All four are disconnected from current job market signals in the search results.
+
+**3. Specific Tools and Frameworks Frontier Companies Prioritize**
+
+Search result [2] states "**More than 70% of hiring managers prioritize familiarity with deployment tools and cloud platforms** like AWS, Azure, and GCP—even for entry-level roles" and emphasizes "prompt management systems, semantic search, multi-agent architectures, and robust monitoring dashboards"[2]. 
+
+**No response addresses these specific tool requirements or the 70% hiring manager priority for deployment platforms**, which directly contradicts the open-source vs. private debate—the real differentiator appears to be deployment and monitoring expertise, not code visibility.
+
+---
+
+### Accuracy Scorecard
+
+| Response | Major Errors | Unsupported Claims | Missing 2026 Context | Usability |
+|----------|--------------|-------------------|----------------------|-----------|
+| **Gemini** | 1 (FDE confusion) | 3+ (open-source strategy claims) | Yes (no FDE/2026 guidance) | Moderate |
+| **GPT** | 1 (frontier preference inference) | 2 (hiring preference claims) | Yes (no current benchmarks) | Moderate |
+| **Grok** | 2 (benchmark fabrication is critical; cultural assumptions) | 4+ (confidentiality, IP signals, benchmarks) | Yes (claims "late 2025" data unsourced) | **Low** |
+| **Claude** | 1 (FDE confusion) | 3+ (company monitoring, signal claims) | Yes (no 2026 hiring specifics) | Moderate |
+
+---
+
+### Recommendations for Accuracy
+
+1. **Ground all claims in hiring signals from search result [2]**: Real 2026 expectations focus on deployment, monitoring, and integration—not open vs. private status.
+2. **Reference FDE role specifics from [1]** if discussing frontier company hiring.
+3. **Remove all benchmark and performance claims** unless directly cited—Grok's "0.7% gap" fabrication is a credibility killer.
+4. **Replace cultural assumptions** (e.g., "frontier labs value discretion") with evidence-based claims about the tools and deployment skills actually emphasized in current job postings.
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+[VERIFIED] When targeting AI Product Engineer roles at frontier AI companies, the choice between building open-source versus private AI portfolio projects involves several trade-offs, as confirmed by live research.
+
+
+1. **Role-Specific Skills and Expectations**
+   [VERIFIED] For roles such as Frontier Deployment Engineer, candidates require skills in full-stack development, AI understanding, and product sense. These include tasks like API design and configuring monitoring systems. Portfolios should thus focus on demonstrating such competencies [1].
+
+2. **Visibility and Networking**
+   - **Open Source:** Offers greater visibility, allowing others to see your work, which can attract feedback, collaboration, and attention from recruiters. This engagement with the community can enhance your reputation within the AI field [UNCERTAIN]. However, the live research does not specifically confirm that frontier companies prioritize open-source contributions in hiring decisions.
+   - **Private:** Limits organic discovery but can be strategically used to highlight discretion and a nuanced understanding of confidentiality, valued highly in many frontier AI companies [UNCERTAIN].
+
+3. **Intellectual Property and Competitive Edge**
+   - **Open Source:** Can lead to a loss of exclusivity. Sharing projects openly might undermine your competitive advantage as innovations become accessible to others. However, it also forces better engineering discipline, which is crucial for developing robust, production-quality code [UNCERTAIN].
+   - **Private:** Preserves exclusivity, potentially allowing for unique presentation in job interviews. Many frontier AI companies may value the ability to handle sensitive work confidentially [UNCERTAIN].
+
+4. **Feedback and Development**
+   - **Open Source:** Community feedback can drive improvement and learning, accelerating skill development and project refinement. However, this can come at a cost of increased maintenance effort [UNCERTAIN].
+   - **Private:** Lacks external input, possibly slowing iterative development. Yet, it allows experimentation without external constraints, which can align with the innovative spirit sought in frontier AI roles [UNCERTAIN].
+
+5. **Cultural Fit and Company Preferences**
+   - **Open Source:** While the broader AI community values open-source efforts, frontier AI companies may prioritize confidentiality due to competitive and ethical considerations. This varies across companies; some may value public contributions while others emphasize discretion [UNCERTAIN].
+   - **Private:** Aligns well with companies that enforce strict confidentiality and IP protection, possibly making a private project portfolio more appealing [UNCERTAIN].
+
+
+Given these trade-offs, a strategic approach could involve a balanced mix of both open-source and private projects:
+
+1. **Hybrid Strategy:**
+   - **Open-Source Contributions:** Publicly shared basics or general tools that demonstrate a candidate's foundational skills in development and collaboration.
+   - **Private Projects:** More innovative or domain-specific solutions where exclusivity would provide a competitive advantage in job applications.
+
+2. **Highlight Relevant Skills:**
+   Portfolios should showcase experience in real-world AI application deployment, focusing on integration skills, monitoring, and deployment platforms as indicated by current market demands [2].
+
+3. **Focus on the Latest Tools and Technologies:**
+   Candidates should familiarize themselves with tools and frameworks emphasized by over 70% of hiring managers, such as AWS, Azure, and GCP, as well as proficiently using prompt management systems and semantic search algorithms [2].
+
+
+1. **Develop a Mixed Portfolio:** Start by identifying a project that can be publicly open-sourced to showcase technical skills and simultaneously invest in a private project that can demonstrate advanced, proprietary skills or ideas.
+   
+2. **Review Current Job Descriptions:** Align portfolio projects with the skills and tools that are currently in demand by frontier AI companies. Consider using platforms like AWS or GCP within projects to demonstrate expertise in cloud deployment.
+
+3. **Engage with the Community:** Participate in open-source projects relevant to your target roles. Contributing to large, established projects can enhance your visibility and credentials while helping you learn best practices and develop new skills.
+
+By following these steps, candidates can effectively position themselves for AI product engineering roles, leveraging both the visibility of open-source projects and the strategic protection of private endeavors.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/017-ai-engineering-skills-data-engineer-transition.md
+++ b/docs/transcripts/017-ai-engineering-skills-data-engineer-transition.md
@@ -1,0 +1,290 @@
+# ai-roundtable — Full Session
+*ai-roundtable Session*
+*research · smart · April 19, 2026*
+
+---
+
+## Opening Prompt
+
+What are the most important AI engineering skills to develop in 2026 for someone transitioning from data engineering?
+
+---
+
+## Round 1 Responses
+
+### 🟠 Claude
+
+# AI Engineering Skills for Data Engineers Transitioning in 2026
+
+The transition from data engineering to AI engineering is actually quite natural — you're already sitting on foundational infrastructure skills that matter more than ever. But the gap you need to close isn't what most bootcamps will tell you.
+
+## What You Already Have That Matters
+
+Your data engineering background means you understand pipelines, data quality, orchestration, and scale. These remain critical in AI systems — possibly more so now that we're past the "just throw it at an API" phase. The industry learned the hard way that prompt engineering alone doesn't build production systems.
+
+## The Crucial Gaps to Close
+
+### 1. Prompt Engineering and Structured Output Patterns
+
+By 2026, this has evolved beyond writing clever prompts. You need to understand:
+- Structured output formats (JSON mode, function calling, schema-constrained generation)
+- Chain-of-thought patterns and when they actually help vs. add latency
+- Prompt versioning, testing, and regression detection
+- Cost/latency/quality tradeoffs across model tiers
+
+This is closer to API design than copywriting. Your engineering mindset is an advantage here.
+
+### 2. Evaluation Infrastructure
+
+This is where data engineers have a massive edge. AI systems need:
+- Automated eval pipelines (think: CI/CD but for model outputs)
+- Ground truth dataset curation and maintenance
+- Metrics beyond accuracy — coherence, factuality, safety, relevance
+- A/B testing frameworks for prompt/model changes
+- Human-in-the-loop feedback collection and integration
+
+If you can build a robust evaluation harness, you're immediately valuable. Most AI teams are flying blind here.
+
+### 3. Retrieval-Augmented Generation (RAG) Systems
+
+RAG remains the practical path to domain-specific AI applications. You need to understand:
+- Vector databases and semantic search (not just keyword matching)
+- Chunking strategies and their impact on retrieval quality
+- Hybrid search (combining dense vectors with traditional search)
+- When to rerank, when to filter, when to give up and fine-tune
+- Document processing pipelines for diverse formats (PDFs, tables, images)
+
+Your data pipeline skills transfer directly — RAG is fundamentally an ETL problem with embeddings.
+
+### 4. Agent Frameworks and Orchestration
+
+The agent ecosystem continues to evolve, but the core patterns persist: systems that plan, use tools, and iterate. You need familiarity with:
+- Tool/function calling patterns
+- State management across multi-turn interactions
+- Error handling, retry logic, and fallback strategies
+- Cost and latency budgets (agents can rack up tokens fast)
+- Memory systems for long-running interactions
+
+Think of this as workflow orchestration (Airflow, Prefect) but with LLMs as unreliable workers.
+
+### 5. Fine-Tuning Literacy
+
+You don't need to become an ML researcher, but you should understand:
+- When fine-tuning actually helps vs. better prompting/RAG
+- LoRA and parameter-efficient methods
+- Supervised fine-tuning vs. RLHF vs. DPO
+- Data requirements and quality bar for training sets
+- Distillation approaches for cost optimization
+
+Your data engineering skills are directly applicable to training data curation — this is often the bottleneck.
+
+### 6. Observability and Debugging
+
+LLM systems are non-deterministic and opaque. You need:
+- Tracing frameworks (LangSmith, Phoenix, Arize, or custom instrumentation)
+- Token usage and cost monitoring
+- Latency profiling across chains/agents
+- Failure pattern detection and alerting
+- Drift detection for model behavior over time
+
+This is monitoring for systems that hallucinate. Your ops background is highly relevant.
+
+### 7. Security and Safety Considerations
+
+Often overlooked but increasingly critical:
+- Prompt injection vulnerabilities and mitigations
+- Output filtering and guardrails
+- PII handling in prompts and outputs
+- Access control for sensitive data in RAG systems
+
+## What's Overrated
+
+**Deep learning theory and model architecture details.** Unless you're training frontier models, you're mostly consuming them via APIs. Understanding transformer mechanics is useful context but rarely actionable day-to-day.
+
+**Chasing every new model release.** The model layer is commoditizing — being tool-agnostic and focused on the system around the model matters more than betting on specific vendors.
+
+## Concrete Learning Path
+
+**Weeks 1-2:** Build a RAG system end-to-end. Start with LangChain or LlamaIndex but quickly graduate to understanding what they're abstracting. Use your own data — something messy and real.
+
+**Weeks 3-4:** Add evaluation. Create a test set, define metrics, automate scoring. Make a change and prove it's better (or worse). Experience the difficulty of measuring "quality."
+
+**Weeks 5-6:** Build a simple agent. Let it use 2-3 tools (search, calculator, database query). Watch it fail. Fix the failure modes. Add guardrails.
+
+**Weeks 7-8:** Instrument everything. Add tracing, cost tracking, latency monitoring. Find your bottlenecks. Set up alerts for anomalies.
+
+**Ongoing:** Read production post-mortems and case studies. Follow practitioners sharing real deployment challenges. The field is learning by doing, not from textbooks.
+
+## Your Unfair Advantage
+
+Data engineers understand that 80% of the work is unglamorous plumbing. That's exactly what production AI systems need. While others chase the latest model or framework, you can build the boring infrastructure that actually ships: versioned datasets, reproducible evaluations, monitored deployments, cost controls, and reliable data pipelines.
+
+The market is starved for people who can make AI systems reliable and maintainable, not just impressive in demos. Your instincts around data quality, pipeline reliability, and operational excellence translate directly — you just need to learn the AI-specific vocabulary and patterns wrapped around them.
+
+### 🔵 Gemini
+
+For a data engineer targeting an AI engineering role by 2026, the transition is an evolution, not a replacement of skills. Your expertise in data pipelines, infrastructure, and governance is the ideal foundation. The key is to extend these skills to manage the unique lifecycle, computational demands, and risks of production-grade AI systems.
+
+Here are the most important skills to develop, framed as extensions of your current data engineering capabilities.
+
+### 1. Production-Grade MLOps and Lifecycle Management
+This is the most critical extension of a data engineer's skillset. While you are an expert at building data pipelines (ETL/ELT), MLOps is about building and automating the *entire model lifecycle*.
+
+*   **From Data Pipelines to ML Pipelines:** Move beyond tools like Airflow for data movement to orchestrating model training, evaluation, and deployment using platforms like **Kubeflow**, **SageMaker Pipelines**, or **Vertex AI Pipelines**.
+*   **CI/CD for Models (CI/CD/CT):** Apply your DevOps knowledge to machine learning. Master CI for code/data validation, CD for model deployment, and the crucial addition of Continuous Training (CT) to automate retraining on new data or to combat model drift.
+*   **Experiment Tracking & Model Registries:** Become proficient with tools like **MLflow** or **Weights & Biases** to log experiments, compare model performance, and manage model versions in a central registry.
+*   **Feature Stores:** Leverage your data modeling skills to design and manage feature stores (**Feast**, **Tecton**). This involves creating systems that provide consistent, low-latency features for both model training and real-time inference, solving the online/offline skew problem.
+
+### 2. Engineering for Generative AI and LLMs
+By 2026, proficiency with Large Language Models (LLMs) and other generative models will be table stakes. Your role is to build the robust systems that make them useful and reliable.
+
+*   **Vector Databases & Retrieval-Augmented Generation (RAG):** This is a natural fit for a data engineer. Master the process of creating embedding pipelines and managing vector databases (**Pinecone**, **Chroma**, **Weaviate**). Architecting efficient RAG systems to ground LLMs in proprietary data will be a core AI engineering task.
+*   **Understanding Foundational Architectures:** You don't need to be a research scientist, but you must understand the practical implications of architectures like **Transformers**. Know their data input requirements (tokenization), computational costs (GPU memory), and failure modes to build effective data preprocessing and deployment infrastructure.
+*   **Fine-tuning and Prompt Engineering at Scale:** Develop the engineering pipelines required to manage, version, and deploy fine-tuned models and complex prompt chains. This includes building systems for evaluating the outputs of these models for quality, safety, and accuracy.
+
+### 3. High-Performance AI Infrastructure & Optimization
+AI workloads have unique infrastructure demands that go beyond typical data processing. Your cloud and distributed systems knowledge is the starting point.
+
+*   **Containerization and Orchestration:** Deepen your expertise in **Docker** and **Kubernetes**. Almost all modern MLOps platforms and model serving frameworks run on Kubernetes, making it essential for scalable AI deployment.
+*   **Hardware Acceleration:** Gain practical experience with GPUs and TPUs. This means understanding how to provision them on the cloud (e.g., AWS, GCP, Azure), optimize data pipelines to prevent I/O bottlenecks and maximize utilization, and use frameworks for distributed training (**Ray**, **Horovod**).
+*   **Model Optimization and Serving:** Learn techniques to make models performant in production. This includes model quantization, distillation, and using high-performance serving frameworks like **NVIDIA Triton Inference Server** or **vLLM** to handle concurrent requests with low latency.
+
+### 4. Responsible AI and Governance
+Your experience with data governance is a major advantage here. Extend it from protecting data to ensuring the entire AI system is fair, transparent, and compliant.
+
+*   **Bias & Fairness Auditing:** Learn to integrate tools and libraries into your ML pipelines to automatically scan training data and model predictions for statistical bias.
+*   **Explainability (XAI):** Implement systems that can generate model explanations on demand using techniques like **SHAP** or **LIME**. This is crucial for debugging, stakeholder trust, and regulatory compliance.
+*   **Monitoring for AI-Specific Risks:** Go beyond monitoring system uptime. Build dashboards and alerting systems to track model-specific metrics like **data drift**, **concept drift**, and prediction confidence to know when a model is degrading in production.
+
+### 5. Advanced Software Engineering Principles
+As an AI Engineer, you are first and foremost an engineer. The gap between a data scientist's prototype and a production system is filled with solid software engineering.
+
+*   **API Development:** Become an expert at building robust, well-documented APIs (e.g., using **FastAPI**) to serve model predictions.
+*   **Testing for AI Systems:** Develop a testing mindset that goes beyond traditional unit and integration tests. This includes data validation tests, model evaluation tests against predefined benchmarks, and tests for robustness and fairness.
+*   **Modular and Reusable Code:** Practice writing clean, modular, and maintainable code for data processing, feature engineering, and model training, enabling collaboration and scalability.
+
+### 🟢 GPT
+
+In 2026, transitioning from data engineering to AI engineering involves focusing on these essential skills:
+
+1. **Machine Learning and Deep Learning**: 
+   - Master building, deploying, and tuning machine learning models, with a strong grasp of both supervised and unsupervised learning techniques.
+   - Enhance understanding of deep learning, particularly neural networks, utilizing frameworks like TensorFlow and PyTorch.
+
+2. **Programming and Software Development**: 
+   - Hone proficiency in programming languages such as Python and R for developing and optimizing machine learning algorithms.
+   - Embrace robust software engineering practices, including version control (e.g., Git) and thorough testing principles.
+
+3. **Cloud Computing and Infrastructure**: 
+   - Gain expertise in using cloud services from providers like AWS, Google Cloud, or Azure to effectively deploy and scale AI solutions.
+
+4. **Data Management and Processing**: 
+   - Capitalize on your data engineering background to manage and process large datasets adeptly using platforms like Apache Spark and Hadoop.
+
+5. **AI Ethics and Explainability**: 
+   - Delve into the ethical considerations of AI and develop skills to ensure models are interpretable and align with transparency standards.
+
+6. **MLOps**: 
+   - Acquire knowledge in MLOps practices to streamline the lifecycle of machine learning models, from development to production and maintenance.
+
+7. **Natural Language Processing (NLP)**: 
+   - Dive into emerging NLP techniques due to their widespread application potential across different sectors.
+
+8. **Continual Learning and Adaptability**: 
+   - Commit to ongoing education and adaptability by keeping up with the latest AI developments and innovations in tools and methodologies.
+
+By developing these skills, you'll be well-equipped to successfully transition into AI engineering.
+
+---
+
+## Perplexity Audit
+*Fact-check findings — live web*
+
+# Fact-Check Audit: Data Engineer→AI Engineer Transition (2026)
+
+## Section 1: Critical Factual Errors
+
+**Error 1: "Batch-to-streaming shift accelerated post-2025 LLM boom"**
+The pre-research context claims streaming is a new priority post-2025, but the search results indicate streaming integration is part of a broader shift toward **real-time, heterogeneous compute**—not a recent acceleration. Source [2] states "heterogeneous compute is no longer optional" and "scheduling has to be policy-driven," suggesting this was already underway by early 2026, not newly accelerated.[2]
+
+**Error 2: Salary benchmarks lack 2026 currency**
+The pre-research context cites Glassdoor/Levels.fyi from "Mar 2026" with $180K–$250K ranges, but provides no verification against actual April 2026 market data in the search results. The search results don't contain salary data, so these figures are unvalidated for current accuracy.
+
+**Error 3: "Prompt engineering declining, context engineering rising"**
+The Alibaba Cloud reference claims prompting is "declining" in favor of context engineering, but search results [1] and [2] emphasize both—not replacement. Source [1] describes "building *for* AI and building *with* AI" as simultaneous capabilities, not a sequential shift.[1][2]
+
+---
+
+## Section 2: Top 3 Missing Critical Information from 2026 Market
+
+**Gap 1: AI fluency as the hiring dividing line (critical oversight)**
+The pre-research context omits the **sharpest market signal from Q1 2026**: data engineers are splitting into two cohorts—those with AI fluency (hired) and those focused on legacy pipeline maintenance (at risk). Source [1] explicitly states "the divide is AI fluency" and that "data engineering roles continued to grow" while tech jobs were cut 71,000 in Q1 2026. This is the most important employment reality for the transition and is entirely absent from the pre-research framing.
+
+**Gap 2: The commoditization of pipeline-building work**
+The pre-research context recommends skills like "data pipelines" and "orchestration" as foundational, but source [1] directly contradicts this: "AI has commoditised the 'data' part of data engineering (writing SQL, scaffolding DAGs, generating transformations)." LLMs now handle boilerplate, making these skills less differentiating. The real value is now "architecture, governance, judgment, cost optimisation."[1]
+
+**Gap 3: The shift in data consumers (RAG, feature stores, agentic AI)**
+While the pre-research mentions RAG systems, it misses the structural reframe: source [1] emphasizes that "the consumer list looks completely different" in 2026. RAG pipelines need "chunked, embedded, well-attributed data served with low latency," and agentic systems need "context-rich, governed data." This is not just a technical update—it's a fundamental change in *who uses the data* and what contracts the data must fulfill.
+
+---
+
+## Section 3: Misalignments with Current 2026 Reality
+
+**Misalignment 1: Overemphasis on deep learning and model architecture**
+The pre-research context recommends "deep learning," "TensorFlow," "PyTorch," and "transformer mechanics," but source [2] and [1] reveal the actual 2026 landscape: data engineers building *for* AI systems (not training models) need to focus on **data contracts, versioning, low-latency serving, and governance**—not model internals. Source [1] notes "what AI can't do is the harder stuff: understanding which business process depends on which data contract."[1][2]
+
+**Misalignment 2: Tool-agnostic stance obscures the urgency of vector databases and real-time infrastructure**
+The pre-research context advises against "betting on specific vendors" and chasing "every new model release," which is reasonable—but it downplays how rapidly **non-optional** infrastructure has become. Source [2] states "heterogeneous compute is no longer optional" and agents must run "as a first-class operational pattern," not ad-hoc. The 2026 market doesn't reward tool-agnosticism; it rewards rapid adoption of agent-native platforms and real-time fabric.[2]
+
+**Misalignment 3: Evaluation and observability underestimated relative to governance**
+The pre-research suggests "evaluation infrastructure" and "observability" as key gaps, which is valid—but source [1] elevates **governance architecture** as equally critical. The 2026 shift isn't just about testing LLM outputs; it's about "designing governance into a system instead of bolting it on later" and understanding "how a schema change will cascade across a dozen downstream consumers" in an AI-augmented architecture.[1]
+
+---
+
+## Section 4: Validation Signals (What the Pre-Research Got Right)
+
+✓ **RAG systems are core** — Correctly identified; source [1] confirms chunked, embedded data for RAG is a primary use case.[1]
+
+✓ **MLOps and production systems matter** — Aligned; source [2] emphasizes "the job shifts from plumbing and pipeline babysitting toward architecture."[2]
+
+✓ **Data engineering as foundation, not replacement** — Correct framing; source [1] confirms "data engineering roles continued to grow" even amid job cuts, and the skills are *evolving*, not disappearing.[1]
+
+✓ **Hands-on learning over theory** — Valid; sources [1][2] both stress that the "real shift happened: not in the tools, but in *who the work is for*."[1]
+
+---
+
+## Synthesis
+*Claude · incorporating all rounds*
+
+In 2026, transitioning from data engineering to AI engineering requires an evolved skill set that builds on your existing data management expertise while embracing new capabilities essential for AI-driven environments. Here are the most critical skills and insights based on the latest research and expert analyses:
+
+1. **AI Fluency and Governance**: According to current 2026 insights, the market is sharply divided between data engineers with AI fluency and those focused on legacy systems [VERIFIED]. The critical gap to bridge is understanding how to architect, govern, and optimize AI systems. This involves designing data governance into systems, understanding cascading impacts of schema changes, and aligning systems with business processes [VERIFIED].
+
+2. **Advanced MLOps and Low-Latency Systems**: The transition involves moving from traditional data pipelines to ML pipelines that automate the entire model lifecycle, including continuous training and deployment [Gemini]. Mastering systems like Kubeflow or Vertex AI Pipelines is crucial for operationalizing machine learning models [Gemini]. Understanding low-latency data serving and governance [VERIFIED] is equally vital as rapid infrastructure adoption is now necessary [VERIFIED].
+
+3. **Vector Databases and RAG Implementation**: With data consumers evolving to need context-rich, governed data, proficiency in retrieval-augmented generation (RAG) becomes crucial [VERIFIED]. This includes managing vector databases (e.g., Pinecone, Weaviate) and architecting pipelines that support efficient retrieval and embedding of data [Gemini].
+
+4. **Evaluation Infrastructure and Observability**: Building robust evaluation systems is an area where data engineers excel, as AI systems require automated evaluation pipelines and metrics beyond accuracy—for coherence, factuality, safety, and relevance [Claude]. Coupled with comprehensive observability, such as tracing, latency monitoring, and performance alerts, this skill ensures AI systems are both reliable and optimally functioning [Claude].
+
+5. **Agentic Systems and Tool Orchestration**: Understanding agent frameworks that plan, use tools, and iterate in AI systems is key [Claude]. Mastering orchestration in complex AI environments where agents require state management and interaction logistics is necessary for scaling AI operations [Claude].
+
+6. **Responsible AI Practices**: As AI governance becomes integral, skills related to bias auditing, explainability, and monitoring AI-specific risks—such as data and concept drift—are necessary for ensuring transparency and compliance [Gemini].
+
+**Contradictions and Updates**:
+- **AI Fluency**: Perplexity identified that AI fluency divides market success for data engineers in 2026, contradicting some round-1 models that didn't highlight this critical difference [VERIFIED].
+- **Governance and Shift in Data Consumers**: Unlike earlier views that placed deep learning and specific architectures front and center, current insights focus on data governance and RAG as central [VERIFIED].
+
+**Next Steps**:
+1. **Engage in AI Fluency Development**: Start by enrolling in online courses or workshops that focus on AI governance and data contracts, which are key differentiators in current job markets.
+   
+2. **Experiment with MLOps and Vector Databases**: Create a personal project that involves building a RAG system using tools like LangChain or TensorFlow Extended (TFX) to enhance your practical knowledge.
+
+3. **Join AI and Data Engineering Communities**: Participate in forums, conferences, and workshops where industry professionals share the latest trends and practical experiences with evolving AI technologies, ensuring you stay at the cutting edge of this fast-paced field.
+
+These concrete steps will position you well for the evolving demands of AI engineering in 2026, leveraging your existing data expertise while integrating new, essential knowledge areas.
+
+---
+
+*Generated by ai-roundtable*
+*Putting the best frontier minds to work.*
+*github.com/JSTcurious/ai-roundtable*

--- a/docs/transcripts/README.md
+++ b/docs/transcripts/README.md
@@ -19,7 +19,10 @@ Sessions 001-011 cover the first two weeks of production testing, spanning the
 Gemini Flash intake rewrite (transcripts 009-011) and earlier direct-question sessions
 that established the baseline for guardrail behavior. Session 012 is the first
 validation transcript for the four-model round-1 architecture (Claude added as a
-research seat) and the removal of the observation gate.
+research seat) and the removal of the observation gate. Sessions 013-017 (April 18-19
+2026) validate the smart/deep tier split, the WebSocket reconnect fix, and the
+always-smart intake lock — including the first deep-tier run with a claim-by-claim
+Perplexity audit.
 
 Recurring patterns documented across the suite:
 - **Tag adoption**: 0% in sessions 001-003, first adoption in session 005 (offshore wind RCA),
@@ -51,3 +54,9 @@ Recurring patterns documented across the suite:
 - [010 — AI engineering project plan (clarifying turn — ambiguous prompt resolved in one exchange)](./010-ai-engineering-project-plan.md)
 - [011 — ISO-NE installed capacity (tier=quick, SYNTHESIS_TRUST_HIERARCHY regression pass)](./011-isone-installed-capacity.md)
 - [012 — ISO-NE offshore wind four-model round-1 validation (Claude sole contributor — all four tags used, observation gate removed)](./012-isone-offshore-wind-four-model-round1.md)
+- [013-alt — ISO-NE offshore wind four-model round-1 (stray export, same prompt as 012 — alternate run)](./013-isone-offshore-wind-four-model-round1-alt.md)
+- [013 — ISO-NE offshore wind smart tier smoke test (WebSocket fix confirmed working, Perplexity returned ISO-NE content correctly · smart · Apr 18 2026)](./013-isone-offshore-wind-smart-tier-smoke-test.md)
+- [014 — ISO-NE offshore wind deep tier validation (comprehensive claim-by-claim audit — Gemini's FERC approval fabrication caught by synthesis · deep · Apr 19 2026)](./014-isone-offshore-wind-deep-tier-validation.md)
+- [015 — MCP and agentic workflows 2026 (Perplexity confirmed 97M downloads, Linux Foundation governance shift Dec 2025, four-protocol A2A stack · smart · Apr 19 2026)](./015-mcp-agentic-workflows-2026.md)
+- [016 — Open source vs private portfolio for frontier AI roles (Perplexity flagged "frontier AI companies" term confusion — FDE vs AI PE roles, deployment skills over visibility · smart · Apr 19 2026)](./016-open-source-vs-private-portfolio.md)
+- [017 — AI engineering skills for data engineer transition (Perplexity surfaced AI fluency as hiring dividing line, pipeline commoditization finding · smart · Apr 19 2026)](./017-ai-engineering-skills-data-engineer-transition.md)


### PR DESCRIPTION
## What
Documents five test sessions from April 18-19, 2026.

## Changes
- Stray file renamed: ai-roundtable-2026-04-17 (12).md → 013-isone-offshore-wind-four-model-round1-alt.md
- 013: ISO-NE offshore wind — Smart tier smoke test (WebSocket fix confirmed)
- 014: ISO-NE offshore wind — Deep tier validation (Gemini FERC fabrication caught)
- 015: MCP agentic workflows 2026 (Linux Foundation governance, A2A protocol)
- 016: Open source vs private portfolio (frontier AI company term confusion flagged)
- 017: AI engineering skills for data engineer transition (pipeline commoditization finding)
- README index updated with all six entries