### PR TITLE
feat(intake): promote Claude Sonnet to primary, demote GPT-4o Mini to…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,25 @@ This is not a tagline. It is a constraint that eliminates a large class of featu
 
 ---
 
+## Model Philosophy
+
+ai-roundtable targets high-stakes decisions where getting it
+right once is worth more than iterating cheaply. Cost is not
+a design constraint. Model choices are made for quality
+ceiling, not cost floor.
+
+### Model assignments by stage
+| Stage            | Model              | Rationale                              |
+|------------------|--------------------|----------------------------------------|
+| Intake           | Claude Sonnet      | Full intent capture drives everything downstream |
+| Research (Smart) | Sonnet → Opus      | Executor/advisor split for depth       |
+| YOUR TAKE chips  | Claude Sonnet      | Chip quality determines user engagement |
+| Synthesis        | Claude Opus        | This is the deliverable                |
+| Fact-check       | Perplexity         | Live web grounding                     |
+| Fallback (intake)| GPT-4o Mini → Qwen | Resilience, not quality targets        |
+
+---
+
 ## v1 Architecture
 
 ### Core Design Principle

--- a/backend/intake.py
+++ b/backend/intake.py
@@ -1,18 +1,17 @@
 """
 backend/intake.py
 
-Gemini Flash-powered intake for ai-roundtable v2.
-
-Analyzes the user's prompt in a single API call. Asks at most one clarifying
-question. Auto-assigns tier (quick / smart / deep) and returns an optimized
-prompt ready for the roundtable.
+Claude Sonnet-powered intake. Captures full user intent across 2-4 turns
+before routing to the research pipeline.
+Fallback: GPT-4o Mini → Qwen 2.5 72B → passthrough.
 
 Classes:
     IntakeSession  — manages a single intake session (at most two turns)
 
 Functions:
-    sanitize_text   — strip Unicode bidi control characters
-    sanitize_config — recursively sanitize string values in a config dict
+    call_intake_sonnet — primary intake via Claude Sonnet (Anthropic)
+    sanitize_text      — strip Unicode bidi control characters
+    sanitize_config    — recursively sanitize string values in a config dict
 """
 
 import logging
@@ -23,6 +22,43 @@ from backend.models.intake_decision import IntakeDecision
 from backend.models.resilient_caller import call_with_fallback
 
 logger = logging.getLogger(__name__)
+
+
+def call_intake_sonnet(prompt: str) -> IntakeDecision:
+    """
+    Primary intake via Claude Sonnet (Anthropic direct API).
+
+    Uses the same system prompt and JSON schema as all other intake providers.
+    Sonnet is the quality ceiling for intake — full intent capture drives
+    everything downstream.
+
+    Raises:
+        ValueError:   if response fails IntakeDecision schema validation.
+        Exception:    on any Anthropic API error (raised immediately; retried
+                      by call_with_fallback via call_with_retry).
+    """
+    from backend.models.anthropic_client import _get_client
+    from backend.models.model_config import INTAKE_PRIMARY
+    from backend.models.openai_client import _build_intake_system_prompt
+
+    system_prompt = _build_intake_system_prompt().strip()
+    response = _get_client().messages.create(
+        model=INTAKE_PRIMARY,
+        max_tokens=512,
+        system=system_prompt,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    raw = response.content[0].text.strip()
+    # Strip markdown fences if Claude wrapped the JSON
+    if raw.startswith("```"):
+        parts = raw.split("```")
+        raw = parts[1].lstrip("json").strip() if len(parts) > 1 else raw
+    try:
+        return IntakeDecision.model_validate_json(raw)
+    except Exception as e:
+        raise ValueError(
+            f"Claude Sonnet intake schema validation failed: {e}. Raw: {raw!r}"
+        )
 
 # Unicode bidi overrides, directional formatting, and other invisible control characters.
 # Ranges covered:
@@ -82,20 +118,19 @@ def call_intake(prompt: str) -> tuple:
     Run intake with fallback chain. Returns (IntakeDecision, provider_used).
 
     Chain:
-        Primary:   INTAKE_PRIMARY   (gpt-4o-mini, OpenAI)
-        Fallback1: INTAKE_FALLBACK1 (qwen-2.5-72b, OpenRouter)
-        Fallback2: INTAKE_FALLBACK2 (claude-haiku, Anthropic)
-        Emergency: Passthrough      (smart tier defaults, never fails)
+        Primary:   Claude Sonnet  (call_intake_sonnet — quality ceiling)
+        Fallback1: GPT-4o Mini    (call_gpt4o_mini_intake — fast, reliable)
+        Fallback2: Qwen 2.5 72B   (OpenRouter — third-provider diversity)
+        Emergency: Passthrough    (smart tier defaults, never fails)
     """
     from backend.models.openai_client import call_gpt4o_mini_intake
     from backend.models.openrouter_client import call_intake_fallback1
-    from backend.models.anthropic_client import call_intake_fallback2
 
     return call_with_fallback(
-        primary_fn=lambda: call_gpt4o_mini_intake(prompt),
+        primary_fn=lambda: call_intake_sonnet(prompt),
         fallback_fns=[
+            lambda: call_gpt4o_mini_intake(prompt),
             lambda: call_intake_fallback1(prompt),
-            lambda: call_intake_fallback2(prompt),
         ],
         emergency_fn=lambda: _intake_passthrough(prompt),
         role="intake",

--- a/backend/models/anthropic_client.py
+++ b/backend/models/anthropic_client.py
@@ -235,6 +235,28 @@ def call_intake_fallback2(prompt: str):
         )
 
 
+def call_for_chips(prompt: str, system: str, max_tokens: int = 200) -> str:
+    """
+    Call Claude Sonnet with a custom prompt/system and return raw text.
+
+    Used by generate_user_take_chips() in router.py for YOUR TAKE chip
+    generation. Same signature as openai_client.call_for_chips so router.py
+    can swap the import without changing call sites.
+
+    No retry — chip generation is best-effort; failures return empty list
+    (fail-open) via the caller's except block.
+    """
+    from backend.models.model_config import INTAKE_PRIMARY
+
+    response = _get_client().messages.create(
+        model=INTAKE_PRIMARY,
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.content[0].text or ""
+
+
 if __name__ == "__main__":
     result = ping()
     if result["ok"]:

--- a/backend/models/model_config.py
+++ b/backend/models/model_config.py
@@ -147,13 +147,14 @@ SYNTHESIS_FALLBACK   = os.getenv("SYNTHESIS_FALLBACK",   "qwen/qwen-2.5-72b-inst
 #
 # Fallback chain uses provider diversity:
 #   Primary:   GPT-4o Mini  (OpenAI — 16/16 eval, $0.23/1K sessions)
-#   Fallback1: Qwen 2.5 72B (OpenRouter — 16/16 eval, different provider)
-#   Fallback2: Claude Haiku (Anthropic — 10/16 eval, last resort)
+#   Primary:   Claude Sonnet (Anthropic — quality ceiling, full intent capture)
+#   Fallback1: GPT-4o Mini  (OpenAI — fast, reliable second choice)
+#   Fallback2: Qwen 2.5 72B (OpenRouter — third provider for diversity)
 #   Emergency: Passthrough  (smart tier defaults, never fails user)
 
-INTAKE_PRIMARY   = os.getenv("INTAKE_PRIMARY",   "gpt-4o-mini")
-INTAKE_FALLBACK1 = os.getenv("INTAKE_FALLBACK1", "qwen/qwen-2.5-72b-instruct")
-INTAKE_FALLBACK2 = os.getenv("INTAKE_FALLBACK2", "claude-haiku-4-5-20251001")
+INTAKE_PRIMARY   = os.getenv("INTAKE_PRIMARY",   "claude-sonnet-4-6")
+INTAKE_FALLBACK1 = os.getenv("INTAKE_FALLBACK1", "gpt-4o-mini")
+INTAKE_FALLBACK2 = os.getenv("INTAKE_FALLBACK2", "qwen/qwen-2.5-72b-instruct")
 
 
 # ── Tier helper functions ─────────────────────────────────────────────────────

--- a/backend/router.py
+++ b/backend/router.py
@@ -604,7 +604,7 @@ async def generate_user_take_chips(
     Returns a list of 3-4 chip strings. Returns [] on any error (fail-open —
     YOUR TAKE still shows without chips).
     """
-    from backend.models.openai_client import call_for_chips
+    from backend.models.anthropic_client import call_for_chips
 
     prompt = (
         f"Research responses:\n{_format_round1_for_chips(round1_responses)}\n\n"

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -267,7 +267,7 @@ class TestResearchAvailabilityStatus:
                    return_value=self._make_gemini_response()):
             import asyncio
             from backend.models.google_client import call_research_gemini_async
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 call_research_gemini_async(
                     [{"role": "user", "content": "test"}],
                     "system",
@@ -292,7 +292,7 @@ class TestResearchAvailabilityStatus:
         with patch("backend.models.openai_client.call_gpt", return_value=resp):
             import asyncio
             from backend.models.openai_client import call_research_gpt_async
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 call_research_gpt_async(
                     [{"role": "user", "content": "test"}],
                     "system",
@@ -314,7 +314,7 @@ class TestResearchAvailabilityStatus:
         with patch("backend.models.grok_client.call_grok", return_value=resp):
             import asyncio
             from backend.models.grok_client import call_research_grok_async
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 call_research_grok_async(
                     [{"role": "user", "content": "test"}],
                     "system",
@@ -330,7 +330,7 @@ class TestResearchAvailabilityStatus:
                    side_effect=RuntimeError("API down")):
             import asyncio
             from backend.models.google_client import call_research_gemini_async
-            text, status = asyncio.get_event_loop().run_until_complete(
+            text, status = asyncio.run(
                 call_research_gemini_async(
                     [{"role": "user", "content": "test"}],
                     "system",
@@ -466,10 +466,10 @@ class TestGenerateUserTakeChips:
         """Fails open — returns [] when the API call raises."""
         import asyncio
         from unittest.mock import patch
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    side_effect=RuntimeError("API down")):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert result == []
@@ -478,10 +478,10 @@ class TestGenerateUserTakeChips:
         """Fails open — returns [] when response is not valid JSON."""
         import asyncio
         from unittest.mock import patch
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value="not json at all"):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert result == []
@@ -490,10 +490,10 @@ class TestGenerateUserTakeChips:
         """Fails open — returns [] when JSON is valid but not a list."""
         import asyncio
         from unittest.mock import patch
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value='{"chips": ["a", "b"]}'):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert result == []
@@ -503,10 +503,10 @@ class TestGenerateUserTakeChips:
         import asyncio
         import json
         from unittest.mock import patch
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value=json.dumps(["Chip A", "Chip B"])):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert result == []
@@ -520,10 +520,10 @@ class TestGenerateUserTakeChips:
             {"label": "Chip A", "evidence": "Evidence for A."},
             {"label": "Chip B", "evidence": "Evidence for B."},
         ]
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value=json.dumps(chips)):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert len(result) == 2
@@ -536,10 +536,10 @@ class TestGenerateUserTakeChips:
         import json
         from unittest.mock import patch
         chips = [{"label": f"Chip {x}", "evidence": "Some evidence."} for x in "ABCDEF"]
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value=json.dumps(chips)):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert len(result) <= 4
@@ -554,10 +554,10 @@ class TestGenerateUserTakeChips:
             {"label": "", "evidence": "Some evidence."},
             {"label": "Another chip", "evidence": ""},
         ]
-        with patch("backend.models.openai_client.call_for_chips",
+        with patch("backend.models.anthropic_client.call_for_chips",
                    return_value=json.dumps(chips)):
             from backend.router import generate_user_take_chips
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 generate_user_take_chips(self._ROUND1, self._AUDIT)
             )
             assert len(result) == 1

--- a/tests/test_your_take_chips.py
+++ b/tests/test_your_take_chips.py
@@ -1,0 +1,141 @@
+"""
+tests/test_your_take_chips.py
+
+Tests for YOUR TAKE chip generation and intake model promotion.
+
+Covers:
+- INTAKE_PRIMARY is Claude Sonnet (not GPT-4o Mini)
+- generate_user_take_chips returns {label, evidence} dicts
+- Parse failure returns []
+- awaiting_user_take WebSocket message contains 'chips' key
+- Synthesize payload includes selected_chips and free_text
+- Missing 'chips' key in awaiting_user_take message is handled gracefully
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+SONNET_ID = "claude-sonnet-4-6"
+
+
+# ── Change 1: Intake primary model ───────────────────────────────────────────
+
+class TestIntakePrimaryModel:
+    def test_intake_primary_is_sonnet(self):
+        from backend.models.model_config import INTAKE_PRIMARY
+        assert INTAKE_PRIMARY == SONNET_ID, (
+            f"INTAKE_PRIMARY must be {SONNET_ID!r}, got {INTAKE_PRIMARY!r}"
+        )
+
+    def test_intake_primary_is_not_gpt4o_mini(self):
+        from backend.models.model_config import INTAKE_PRIMARY
+        assert INTAKE_PRIMARY != "gpt-4o-mini"
+
+
+# ── Change 2: Chip generation returns {label, evidence} dicts ─────────────────
+
+class TestChipGeneration:
+    VALID_CHIPS = json.dumps([
+        {"label": "Trust Gemini on cost structure", "evidence": "Gemini cited specific pricing tiers."},
+        {"label": "Perplexity changes the calculus", "evidence": "Live data contradicted two round-1 claims."},
+        {"label": "I want to explore the risk angle", "evidence": "Grok flagged a downside no other model mentioned."},
+    ])
+
+    def _run_generate(self, mock_raw: str) -> list:
+        """Run generate_user_take_chips with call_for_chips mocked to return mock_raw."""
+        import asyncio
+        from backend.router import generate_user_take_chips
+
+        round1 = {"gemini": "Gemini said X.", "gpt": "GPT said Y.", "grok": "Grok said Z.", "claude": "Claude said W."}
+        factcheck = "Perplexity found one claim was outdated."
+
+        with patch("backend.router.asyncio.to_thread", new=AsyncMock(return_value=mock_raw)):
+            return asyncio.run(
+                generate_user_take_chips(round1, factcheck)
+            )
+
+    def test_chip_generation_returns_label_evidence_list(self):
+        chips = self._run_generate(self.VALID_CHIPS)
+        assert isinstance(chips, list)
+        assert len(chips) > 0
+        for chip in chips:
+            assert "label" in chip, f"Missing 'label' key: {chip}"
+            assert "evidence" in chip, f"Missing 'evidence' key: {chip}"
+            assert isinstance(chip["label"], str) and chip["label"].strip()
+            assert isinstance(chip["evidence"], str) and chip["evidence"].strip()
+
+    def test_chip_generation_parse_failure_returns_empty(self):
+        chips = self._run_generate("not valid json {{{")
+        assert chips == [], f"Expected [] on parse failure, got {chips!r}"
+
+    def test_chip_generation_non_list_json_returns_empty(self):
+        chips = self._run_generate('{"label": "oops", "evidence": "this is an object not array"}')
+        assert chips == []
+
+    def test_chip_generation_filters_malformed_dicts(self):
+        malformed = json.dumps([
+            {"label": "Valid chip", "evidence": "Good evidence here."},
+            {"label": "", "evidence": "Empty label — should be filtered."},
+            {"label": "Missing evidence"},
+            "plain string — should be filtered",
+        ])
+        chips = self._run_generate(malformed)
+        assert len(chips) == 1
+        assert chips[0]["label"] == "Valid chip"
+
+
+# ── awaiting_user_take WebSocket message ──────────────────────────────────────
+
+class TestAwaitingUserTakeMessage:
+    def test_chips_injected_into_awaiting_user_take_message(self):
+        """
+        The awaiting_user_take payload always includes a 'chips' key.
+        Verify by inspecting the message structure produced by main.py's
+        session handler.
+        """
+        # Construct the exact dict the session handler sends
+        chips = [
+            {"label": "Trust Gemini", "evidence": "Gemini was most detailed."},
+        ]
+        payload = {
+            "type": "awaiting_user_take",
+            "chips": chips,
+            "message": "Here are some perspectives to consider:" if chips else "",
+        }
+        assert "chips" in payload
+        assert isinstance(payload["chips"], list)
+
+    def test_chips_missing_does_not_crash(self):
+        """
+        Frontend initializes userTakeChips from data.chips using `data.chips || []`.
+        Simulate a payload without 'chips' and confirm the fallback resolves to [].
+        """
+        payload = {"type": "awaiting_user_take"}  # no 'chips' key
+        user_take_chips = payload.get("chips") or []
+        assert user_take_chips == []
+
+
+# ── Synthesize payload ────────────────────────────────────────────────────────
+
+class TestSynthesizePayload:
+    def test_synthesize_payload_includes_selected_chips_and_free_text(self):
+        """
+        build_synthesis_system receives a dict with selected_chips and free_text.
+        Verify both keys are present and used.
+        """
+        from backend.router import build_synthesis_system
+
+        user_take_data = {
+            "selected_chips": ["chip A"],
+            "free_text": "my perspective",
+        }
+        system_prompt = build_synthesis_system(user_take_data)
+
+        # The system prompt must incorporate the user's take data
+        assert isinstance(system_prompt, str)
+        assert len(system_prompt) > 0
+        # selected_chips labels and free_text both appear in the synthesis prompt
+        assert "chip A" in system_prompt
+        assert "my perspective" in system_prompt


### PR DESCRIPTION
## feat/your-take-chips

### Model upgrades
- Intake primary: GPT-4o Mini → Claude Sonnet (claude-sonnet-4-6)
- YOUR TAKE chip generation: GPT-4o Mini → Claude Sonnet
- Haiku removed from intake fallback chain
- Fallback chain: Sonnet → GPT-4o Mini → Qwen 2.5 72B → passthrough

### Why
ai-roundtable is a deliberation layer for high-stakes decisions.
Cost is not a design constraint. Model choices are made for quality
ceiling, not cost floor. Intake determines everything downstream —
weak intake produces shallow context that no research tier recovers.

### Tests
- Added tests/test_your_take_chips.py (9 tests)
- Fixed asyncio.get_event_loop() → asyncio.run() in
  test_resilience.py and test_model_config.py
- Full suite: 223 passed, 0 failed, Python 3.13.12

### Docs
- ARCHITECTURE.md: Model Philosophy section added with
  stage-level model assignment table