### PR TITLE
feat: UX fixes, model quality, env loading

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -31,21 +31,9 @@ import uuid
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from dotenv import load_dotenv
 
-def _load_env():
-    """Load backend/.env at import time so API keys are available regardless of how the server is started."""
-    env_path = Path(__file__).parent / ".env"
-    if not env_path.exists():
-        return
-    with open(env_path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            k, _, v = line.partition("=")
-            os.environ.setdefault(k.strip(), v.strip())
-
-_load_env()
+load_dotenv(Path(__file__).parent / ".env", override=False)
 
 from fastapi import FastAPI, HTTPException, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
@@ -1148,7 +1136,7 @@ async def session_websocket(websocket: WebSocket):
 
         # ── Synthesis: route to analytical or factual model based on audit ────
         synthesis_model_id, synthesis_route = select_synthesis_model(audit_text)
-        synthesis_system = build_synthesis_system(user_take_data)
+        synthesis_system = build_synthesis_system(user_take_data, citations=citations)
         synthesis_messages = [{"role": "user", "content": prompt}]
 
         await websocket.send_json({"type": "synthesis_thinking"})

--- a/backend/models/model_config.py
+++ b/backend/models/model_config.py
@@ -27,6 +27,11 @@ FACTCHECK_DEEP_MAX_TOKENS. See ADR 004 addendum.
 """
 
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env", override=False)
 
 
 # ── Research — Gemini (Google) ────────────────────────────────────────────────

--- a/backend/router.py
+++ b/backend/router.py
@@ -552,19 +552,24 @@ CHIP_GENERATION_SYSTEM = """\
 You have just read four AI research responses and a fact-check audit
 from a deliberation session.
 
-Generate exactly 3-4 perspective chips. Each chip has a short label and
-a brief evidence note that explains why this perspective is worth considering.
+Generate exactly 3-4 perspective chips. Each chip must belong to a DISTINCT
+perspective type. Assign each chip exactly one type from this list:
+  agree     — sides with the research consensus or a specific model
+  skeptical — challenges an assumption or questions cited evidence
+  action    — recommends a concrete next step
+  nuance    — surfaces a tension, trade-off, or overlooked angle
 
 Rules:
+- No two chips may share the same type (mutual exclusivity — one type per chip)
+- Maximum one "skeptical" chip per response
 - Be specific to THIS session's content — not generic
 - Reference specific models, claims, or findings where relevant
-- Include no more than one skeptical or contrarian option — vary perspectives across agreement, skepticism, action, and nuance
-- Include at least one that sides with the fact-check over round-1
-- label: under 8 words
+- Include at least one chip that sides with the fact-check over round-1
+- label: under 8 words, no type prefix in the label text
 - evidence: 2-3 sentences of specific context from the research
 - Return ONLY a valid JSON array of objects, no other text
 
-Example:
+Example (4 chips, all distinct types):
 [
   {"label": "I trust Gemini's framing on this",
    "evidence": "Gemini's analysis was the most detailed on cost structure and aligned with Perplexity's live data. GPT took a more cautious stance that may underestimate the opportunity."},
@@ -649,8 +654,7 @@ The fact-check audit was conducted by a live web search tool and \
 represents the most current grounded information available. Treat \
 it as the highest-trust source for verifiable facts.
 
-{user_take_section}
-Synthesis principles:
+{user_take_section}{citation_section}Synthesis principles:
 - Where fact-check contradicts round-1, side with fact-check and \
 state the contradiction explicitly with the corrected information
 - Where the user expresses skepticism about a model's claim, surface \
@@ -690,7 +694,7 @@ based on the research and fact-check evidence only.
 """
 
 
-def build_synthesis_system(user_take_data: dict) -> str:
+def build_synthesis_system(user_take_data: dict, citations: list = None) -> str:
     """
     Build the Philosophy B synthesis system prompt incorporating user's perspective.
 
@@ -702,6 +706,9 @@ def build_synthesis_system(user_take_data: dict) -> str:
             - "selected_chips": list[str] — chip labels the user toggled on
               (labels only — evidence is for the user's benefit, not synthesis)
             - "free_text": str — user's own typed perspective
+        citations: list of source URLs from the fact-check audit. When provided,
+            instructs Claude to use inline [n] markers that correspond to these
+            sources so the frontend can render them as clickable superscripts.
 
     Returns:
         Complete synthesis system prompt string.
@@ -724,4 +731,20 @@ def build_synthesis_system(user_take_data: dict) -> str:
             user_take="\n".join(parts)
         )
 
-    return SYNTHESIS_SYSTEM_TEMPLATE.format(user_take_section=take_section)
+    citation_section = ""
+    if citations:
+        source_lines = "\n".join(
+            f"[{i + 1}] {url}" for i, url in enumerate(citations)
+        )
+        citation_section = (
+            "Inline citations: when referencing a specific fact-check finding, "
+            "add the corresponding source number inline immediately after the claim "
+            "(e.g. 'Pricing has increased 40% since 2023 [1]'). "
+            "Only cite sources from the numbered list below — do not invent citation numbers.\n\n"
+            f"Sources:\n{source_lines}\n\n"
+        )
+
+    return SYNTHESIS_SYSTEM_TEMPLATE.format(
+        user_take_section=take_section,
+        citation_section=citation_section,
+    )

--- a/frontend/src/components/IntakeFlow.jsx
+++ b/frontend/src/components/IntakeFlow.jsx
@@ -37,6 +37,17 @@ const LOADING_DELAYS = [2000, 5000];
 const TIMEOUT_MS = 15000;
 
 /**
+ * Quick-reply chips shown above the clarifying answer textarea.
+ * Clicking a chip fills the textarea so the user can submit as-is or edit.
+ */
+const QUICK_CHIPS = [
+  "Still early — just exploring",
+  "Need a decision soon",
+  "No hard constraints",
+  "Let me give more context",
+];
+
+/**
  * @param {Object}   props
  * @param {string}   props.initialUserMessage  — prompt from landing page
  * @param {function} props.onComplete          — (session_config) => void
@@ -205,6 +216,24 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
               <p className="text-[0.9375rem] leading-relaxed text-[#e8e8e8]">{clarifyingQuestion}</p>
             </div>
 
+            {/* Quick-reply chips */}
+            <div className="flex flex-wrap gap-2">
+              {QUICK_CHIPS.map((chip) => (
+                <button
+                  key={chip}
+                  type="button"
+                  disabled={submittingAnswer}
+                  onClick={() => {
+                    setAnswer(chip);
+                    answerRef.current?.focus();
+                  }}
+                  className="rounded-full border border-[#3a3a3a] bg-[#1e1e1e] px-3 py-1 text-xs text-[#aaaaaa] transition-colors hover:border-[#F5A623] hover:text-[#F5A623] focus:outline-none disabled:opacity-40"
+                >
+                  {chip}
+                </button>
+              ))}
+            </div>
+
             {/* Answer input */}
             <form
               onSubmit={(e) => { e.preventDefault(); submitAnswer(); }}
@@ -230,7 +259,8 @@ function IntakeFlow({ initialUserMessage, onComplete, onBack }) {
               <button
                 type="submit"
                 disabled={submittingAnswer || !answer.trim()}
-                className="inline-flex h-10 shrink-0 items-center justify-center self-start rounded-lg border border-[#6B6B6B] bg-[#1e1e1e] px-3 text-[#e8e8e8] focus:outline-none disabled:opacity-40"
+                style={{ background: "#F5A623", color: "#0d0d0d" }}
+                className="inline-flex h-10 w-10 shrink-0 items-center justify-center self-start rounded-lg font-bold transition-opacity hover:opacity-90 focus:outline-none disabled:opacity-40"
                 aria-label={submittingAnswer ? "Submitting" : "Submit answer"}
               >
                 <span aria-hidden>{submittingAnswer ? "…" : "→"}</span>

--- a/frontend/src/components/SessionView.jsx
+++ b/frontend/src/components/SessionView.jsx
@@ -281,6 +281,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
   const [sessionComplete, setSessionComplete] = useState(false);
 
   const [leaveIntent, setLeaveIntent] = useState(null);
+  const [copiedAnswer, setCopiedAnswer] = useState(false);
 
   // ── Perplexity citations — shown below FINAL ANSWER ─────────────────────
   const [citations, setCitations] = useState([]);
@@ -717,6 +718,26 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     URL.revokeObjectURL(url);
   }, [synthesisText]);
 
+  const copyFinalAnswer = useCallback(() => {
+    if (!synthesisText || copiedAnswer) return;
+    // Strip confidence tags and markdown before copying to clipboard
+    const plain = synthesisText
+      .replace(/\[VERIFIED\]|\[LIKELY\]|\[UNCERTAIN\]|\[DEFER\]/g, "")
+      .replace(/#{1,6}\s+/gm, "")
+      .replace(/\*\*(.+?)\*\*/g, "$1")
+      .replace(/\*(.+?)\*/g, "$1")
+      .replace(/`(.+?)`/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/^\s*[-*+]\s+/gm, "")
+      .replace(/^\s*\d+\.\s+/gm, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+    navigator.clipboard.writeText(plain).then(() => {
+      setCopiedAnswer(true);
+      setTimeout(() => setCopiedAnswer(false), 1500);
+    });
+  }, [synthesisText, copiedAnswer]);
+
   const toggleChip = useCallback((label) => {
     setSelectedChips((prev) =>
       prev.includes(label) ? prev.filter((c) => c !== label) : [...prev, label]
@@ -750,7 +771,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     if (!onNavigateHome) return;
     if (sessionSettled) {
       await downloadSessionMarkdown();
-      onNavigateHome();
+      // Stay on page — user keeps their session visible after saving
     } else {
       setLeaveIntent("save-exit");
     }
@@ -762,6 +783,8 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
     if (!onNavigateHome) return;
     if (intent === "save-exit") {
       await downloadSessionMarkdown();
+      // Stay on page — download without navigating away
+      return;
     }
     onNavigateHome();
   }, [leaveIntent, onNavigateHome, downloadSessionMarkdown]);
@@ -1254,11 +1277,12 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
               {synthesisFinal && (
                 <button
                   type="button"
-                  onClick={downloadFinalAnswerTxt}
+                  onClick={copyFinalAnswer}
                   className="text-xs text-[#555555] hover:text-text-secondary transition-colors focus:outline-none"
-                  aria-label="Save final answer as text file"
+                  aria-label="Copy final answer to clipboard"
+                  title="Copy to clipboard"
                 >
-                  save
+                  {copiedAnswer ? "Copied ✓" : "copy"}
                 </button>
               )}
             </div>
@@ -1275,6 +1299,7 @@ function SessionView({ sessionConfig, resumeTranscript = null, onSynthesisComple
                   content={synthesisBody}
                   isStreaming={synthesisStreaming && !synthesisFinal}
                   complete={synthesisFinal}
+                  citations={citations}
                 />
               )}
               {/* Sources — citations from Perplexity fact-check */}

--- a/frontend/src/components/SynthesisPanel.jsx
+++ b/frontend/src/components/SynthesisPanel.jsx
@@ -6,17 +6,28 @@
  * Figma frame: 04-Synthesis-Panel
  */
 
-import React from "react";
+import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 /**
- * @param {Object} props
- * @param {string} props.content — synthesis markdown / plain text (streams in)
- * @param {boolean} props.isStreaming — true while synthesis tokens are still arriving
- * @param {boolean} props.complete — synthesis finished (show ✓)
+ * @param {Object}   props
+ * @param {string}   props.content      — synthesis markdown / plain text (streams in)
+ * @param {boolean}  props.isStreaming  — true while synthesis tokens are still arriving
+ * @param {boolean}  props.complete     — synthesis finished (show ✓)
+ * @param {string[]} props.citations    — ordered source URLs from Perplexity fact-check
  */
-function SynthesisPanel({ content, isStreaming, complete }) {
+function SynthesisPanel({ content, isStreaming, complete, citations = [] }) {
+  // Convert [n] citation markers to markdown links when a matching URL exists.
+  // Markers without a URL entry are left as-is (rendered as literal text).
+  const processedContent = useMemo(() => {
+    if (!citations.length) return content;
+    return content.replace(/\[(\d+)\]/g, (match, n) => {
+      const url = citations[parseInt(n, 10) - 1];
+      return url ? `[<sup>${n}</sup>](${url})` : match;
+    });
+  }, [content, citations]);
+
   return (
     <div className="flex max-h-[400px] w-full flex-col overflow-hidden rounded-lg border border-border bg-surface px-4 py-3" style={{ borderLeft: "3px solid #E8712A" }}>
       <div className="mb-2 shrink-0 text-xs font-semibold uppercase tracking-wide text-claude">
@@ -25,7 +36,23 @@ function SynthesisPanel({ content, isStreaming, complete }) {
       </div>
       <div className="synthesis-panel-scroll min-h-0 flex-1">
         <div className="markdown-session break-words text-[0.9375rem] leading-relaxed text-text-primary">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              a: ({ href, children }) => (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[#F5A623] hover:opacity-80 no-underline"
+                >
+                  {children}
+                </a>
+              ),
+            }}
+          >
+            {processedContent}
+          </ReactMarkdown>
           {isStreaming && !complete ? (
             <span
               className="ml-0.5 inline-block h-[1em] w-2 animate-pulse align-[-0.125em] bg-claude"

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -281,7 +281,7 @@ class TestModelInfoEndpoint:
         """Call get_model_info() directly (no HTTP round-trip needed)."""
         import asyncio
         from backend.main import get_model_info
-        return asyncio.get_event_loop().run_until_complete(get_model_info())
+        return asyncio.run(get_model_info())
 
     def test_returns_smart_and_deep_keys(self):
         result = self._call()


### PR DESCRIPTION
## Changes

- **python-dotenv**: explicit backend/.env load in main.py and model_config.py
- **Intake UX**: response chips, amber submit button
- **YOUR TAKE chips**: mutual exclusivity enforced (agree/skeptical/action/nuance)
- **Synthesis**: [n] inline citations as superscript anchors
- **Save**: stays on page after download; copy-to-clipboard replaces save link

## Test results
219 passed, 0 failed — Python 3.13.12

## Notes
Claude unavailable in last test session — transient API timeout,
not a config issue. Client confirmed healthy.