### PR TITLE
fix(synthesis): render citation superscripts as React elements not raw HTML strings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,10 +15,20 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.4.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3329,6 +3339,107 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3337,6 +3448,14 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6132,6 +6251,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.11.2.tgz",
@@ -6643,6 +6769,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9242,6 +9376,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -11285,6 +11429,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -12304,6 +12459,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -14945,6 +15110,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -16351,6 +16530,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,9 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0"

--- a/frontend/src/components/SynthesisPanel.jsx
+++ b/frontend/src/components/SynthesisPanel.jsx
@@ -18,13 +18,15 @@ import remarkGfm from "remark-gfm";
  * @param {string[]} props.citations    — ordered source URLs from Perplexity fact-check
  */
 function SynthesisPanel({ content, isStreaming, complete, citations = [] }) {
-  // Convert [n] citation markers to markdown links when a matching URL exists.
-  // Markers without a URL entry are left as-is (rendered as literal text).
+  // Convert [n] citation markers to markdown links using a custom citation://n
+  // protocol so ReactMarkdown doesn't need to parse raw HTML inside link labels.
+  // The components.a override below detects this protocol and renders a proper
+  // <sup> element. Markers without a matching URL are left as-is.
   const processedContent = useMemo(() => {
     if (!citations.length) return content;
     return content.replace(/\[(\d+)\]/g, (match, n) => {
       const url = citations[parseInt(n, 10) - 1];
-      return url ? `[<sup>${n}</sup>](${url})` : match;
+      return url ? `[${n}](citation://${n})` : match;
     });
   }, [content, citations]);
 
@@ -39,16 +41,35 @@ function SynthesisPanel({ content, isStreaming, complete, citations = [] }) {
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
             components={{
-              a: ({ href, children }) => (
-                <a
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-[#F5A623] hover:opacity-80 no-underline"
-                >
-                  {children}
-                </a>
-              ),
+              a: ({ href, children }) => {
+                // Citation superscript: [n](citation://n) → <a href="url"><sup>n</sup></a>
+                if (href?.startsWith("citation://")) {
+                  const idx = parseInt(href.replace("citation://", ""), 10) - 1;
+                  const url = citations[idx];
+                  if (url) {
+                    return (
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[#F5A623] hover:opacity-80 no-underline"
+                      >
+                        <sup>{children}</sup>
+                      </a>
+                    );
+                  }
+                }
+                return (
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#F5A623] hover:opacity-80 no-underline"
+                  >
+                    {children}
+                  </a>
+                );
+              },
             }}
           >
             {processedContent}

--- a/frontend/src/components/SynthesisPanel.jsx
+++ b/frontend/src/components/SynthesisPanel.jsx
@@ -58,6 +58,9 @@ function SynthesisPanel({ content, isStreaming, complete, citations = [] }) {
                       </a>
                     );
                   }
+                  // citation://n with no matching URL — render plain superscript,
+                  // no broken anchor pointing to a dead protocol
+                  return <sup>{children}</sup>;
                 }
                 return (
                   <a

--- a/frontend/src/components/SynthesisPanel.test.jsx
+++ b/frontend/src/components/SynthesisPanel.test.jsx
@@ -1,0 +1,123 @@
+/**
+ * frontend/src/components/SynthesisPanel.test.jsx
+ *
+ * Verifies that [n] citation markers render as clickable superscript anchors,
+ * not as raw HTML strings like "<sup>5</sup>".
+ *
+ * react-markdown v10 is ESM-only and can't be transformed by CRA's Jest config,
+ * so we mock it with a minimal shim that delegates markdown link rendering to
+ * the components.a prop — which is the exact code path under test.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import SynthesisPanel from "./SynthesisPanel";
+
+// Minimal react-markdown shim: finds [text](href) patterns and calls components.a
+// for each one, passing the children and href — identical to what real ReactMarkdown does.
+jest.mock("react-markdown", () => {
+  return function MockReactMarkdown({ children, components }) {
+    const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+    const parts = [];
+    let last = 0;
+    let match;
+    let key = 0;
+
+    while ((match = LINK_RE.exec(children)) !== null) {
+      if (match.index > last) {
+        parts.push(children.slice(last, match.index));
+      }
+      const [, text, href] = match;
+      const A = components?.a;
+      parts.push(
+        A ? (
+          <A key={key++} href={href}>
+            {text}
+          </A>
+        ) : (
+          <a key={key++} href={href}>
+            {text}
+          </a>
+        )
+      );
+      last = match.index + match[0].length;
+    }
+    if (last < children.length) {
+      parts.push(children.slice(last));
+    }
+
+    return <div>{parts}</div>;
+  };
+});
+
+jest.mock("remark-gfm", () => () => {});
+
+const CITATIONS = [
+  "https://example.com/source-1",
+  "https://example.com/source-2",
+];
+
+describe("SynthesisPanel citation rendering", () => {
+  test("renders [n] markers as superscript anchor elements, not raw HTML strings", () => {
+    render(
+      <SynthesisPanel
+        content="See this claim [1] and also this one [2]."
+        isStreaming={false}
+        complete={false}
+        citations={CITATIONS}
+      />
+    );
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+
+    // First citation — href points to the resolved URL, not citation://
+    const link1 = links[0];
+    expect(link1).toHaveAttribute("href", CITATIONS[0]);
+    expect(link1).toHaveAttribute("target", "_blank");
+    expect(link1).toHaveAttribute("rel", "noopener noreferrer");
+
+    // Must contain a <sup> child, not raw text like "<sup>1</sup>"
+    const sup1 = link1.querySelector("sup");
+    expect(sup1).not.toBeNull();
+    expect(sup1).toHaveTextContent("1");
+
+    // Second citation
+    const link2 = links[1];
+    expect(link2).toHaveAttribute("href", CITATIONS[1]);
+    const sup2 = link2.querySelector("sup");
+    expect(sup2).not.toBeNull();
+    expect(sup2).toHaveTextContent("2");
+
+    // The literal string "<sup>" must not appear anywhere in the rendered output
+    expect(document.body.textContent).not.toContain("<sup>");
+  });
+
+  test("leaves [n] markers without a matching URL as literal text", () => {
+    render(
+      <SynthesisPanel
+        content="Unmatched marker [9] stays as-is."
+        isStreaming={false}
+        complete={false}
+        citations={CITATIONS}
+      />
+    );
+
+    // [9] exceeds the citations array — no anchor should be created
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    expect(screen.getByText(/\[9\]/)).toBeInTheDocument();
+  });
+
+  test("renders no links when citations array is empty", () => {
+    render(
+      <SynthesisPanel
+        content="See this claim [1]."
+        isStreaming={false}
+        complete={false}
+        citations={[]}
+      />
+    );
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/SynthesisPanel.test.jsx
+++ b/frontend/src/components/SynthesisPanel.test.jsx
@@ -120,4 +120,34 @@ describe("SynthesisPanel citation rendering", () => {
     );
     expect(screen.queryAllByRole("link")).toHaveLength(0);
   });
+
+  test("citation://n with no matching URL renders plain <sup>, no broken anchor", () => {
+    // processedContent returns match as-is when citations[n-1] is undefined,
+    // so pre-formed [2](citation://2) in the content survives unchanged and
+    // the mock delivers href="citation://2" to components.a with only 1 citation.
+    render(
+      <SynthesisPanel
+        content="First [1] is valid. Second [2](citation://2) has no URL."
+        isStreaming={false}
+        complete={false}
+        citations={["https://example.com/source-1"]}
+      />
+    );
+
+    // [1] has a URL → renders as an anchor with <sup>
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "https://example.com/source-1");
+    expect(links[0].querySelector("sup")).toHaveTextContent("1");
+
+    // citation://2 has no URL → plain <sup>, no broken anchor
+    const sups = document.querySelectorAll("sup");
+    expect(sups).toHaveLength(2); // one from [1] (inside anchor), one from [2] (standalone)
+    // The standalone <sup> must not be inside an anchor
+    const orphanSup = Array.from(sups).find(
+      (s) => s.closest("a") === null
+    );
+    expect(orphanSup).not.toBeNull();
+    expect(orphanSup).toHaveTextContent("2");
+  });
 });


### PR DESCRIPTION
## Summary

- `[<sup>n</sup>](url)` in the processedContent string was being treated as literal text by ReactMarkdown (v10, no rehype-raw), so users saw `<sup>5</sup>` on screen instead of a rendered superscript anchor
- Fix: replace `[n]` with `[n](citation://n)` — a plain number as link text with a custom protocol — then detect `citation://n` in the existing `components.a` override and wrap `children` in `<sup>`. No new runtime dependencies
- Adds `SynthesisPanel.test.jsx` with 3 cases: citation renders as `<sup>` anchor, unmatched index leaves `[n]` as literal text, empty citations array produces no links

## Test plan

- [ ] `npm test -- --testPathPattern=SynthesisPanel --watchAll=false` — 3 passed
- [ ] Live: run a session that triggers Perplexity fact-check, confirm `[1]`, `[2]` etc. render as amber superscript links opening source URLs in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)