### PR TITLE
fix(deps): pin starlette==0.46.2 to fix WebSocket crash

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -492,6 +492,20 @@ async def export_drive():
 
 # ── WebSocket streaming ───────────────────────────────────────────────────────
 
+async def safe_close(ws):
+    """Close a WebSocket, silently ignoring errors if already closed.
+
+    websocket.close() raises RuntimeError when called after the client has
+    already disconnected (e.g. inside a WebSocketDisconnect handler) or when
+    a prior close frame was already sent.  Swallowing it here lets every
+    call site use a uniform close pattern without try/except boilerplate.
+    """
+    try:
+        await ws.close()
+    except RuntimeError:
+        pass  # Already closed by client or a prior handler
+
+
 def _build_transcript(config: dict, history: list, prompt: str) -> Transcript:
     """Reconstruct a Transcript from prior history and append the new user prompt."""
     transcript = Transcript()
@@ -932,11 +946,11 @@ async def session_websocket(websocket: WebSocket):
         try:
             data = await websocket.receive_json()
         except WebSocketDisconnect:
-            await websocket.close()
+            await safe_close(websocket)
             return
         except Exception:
             await websocket.send_json({"type": "error", "message": "Invalid handshake — expected JSON with prompt and session_config."})
-            await websocket.close()
+            await safe_close(websocket)
             return
         if isinstance(data, dict) and data.get("type") == "ping":
             await websocket.send_json({"type": "pong"})
@@ -953,7 +967,7 @@ async def session_websocket(websocket: WebSocket):
         tier_config = get_tier_config(tier)
     except ValueError as e:
         await websocket.send_json({"type": "error", "message": str(e)})
-        await websocket.close()
+        await safe_close(websocket)
         return
 
     # Tier must be "smart" or "deep" — anything else defaults to smart
@@ -1194,4 +1208,4 @@ async def session_websocket(websocket: WebSocket):
             await ping_task
         except asyncio.CancelledError:
             pass
-        await websocket.close()
+        await safe_close(websocket)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn[standard]
+starlette==0.46.2
 anthropic
 openai
 google-genai

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
-uvicorn[standard]
+uvicorn[standard]==0.32.1
 starlette==0.46.2
 anthropic
 openai


### PR DESCRIPTION
## Summary

Three-part fix for WebSocket crashes introduced by starlette 1.0.0 / uvicorn 0.44.0.

### Fix 1 — pin starlette==0.46.2

`starlette==1.0.0` removed `WebSocketProtocol.transfer_data_task`; `uvicorn==0.44.0` still references it on teardown:

```
AttributeError: 'WebSocketProtocol' object has no attribute 'transfer_data_task'.
```

Killed the WebSocket mid-session → all model responses showed as unavailable.

### Fix 2 — pin uvicorn[standard]==0.32.1

Fixing starlette exposed a second bug: `uvicorn 0.33+` changed WebSocket teardown in a way that sends a duplicate close frame against `starlette 0.46.x`:

```
RuntimeError: Unexpected ASGI message 'websocket.close',
after sending 'websocket.close' or response already completed.
```

`0.32.1` is the last release before those teardown changes.

### Fix 3 — safe_close() helper in main.py

The double-close `RuntimeError` also fires regardless of uvicorn version when:
- `websocket.close()` is called inside a `WebSocketDisconnect` handler (client already closed)
- the `finally` block fires after the client disconnected mid-session

Added `safe_close(ws)` near the WebSocket section and replaced all four `websocket.close()` call sites with `await safe_close(websocket)`. Swallows `RuntimeError` silently; no other logic changed.

## Result

- `starlette==0.46.2` ✓ (explicit in requirements.txt)
- `uvicorn==0.32.1` ✓ (explicit in requirements.txt)
- All four close() sites guarded ✓

## Test plan

- [x] `python3 -m pytest tests/ -q` — 223 passed, 0 failures
- [ ] Live session: restart backend (`uv run uvicorn backend.main:app --reload --port 8000`), run a full session, confirm no WebSocket errors in logs and Claude appears in Round 1

> Do not merge without live session confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)