### PR TITLE
feat(intake): replace optimized_prompt with 5-section research brief

### DIFF
--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -301,12 +301,43 @@ PROPER NOUN PRESERVATION — CRITICAL:
   Never substitute model names, product names, version numbers, company
   names, or any named entity the user provided. Use them exactly as written.
 
-optimized_prompt: refined, context-enriched version of the user's
-  prompt. Preserve ALL user-provided proper nouns exactly.
-  For immigration cases: include visa type, case stage, and
-  employer dependency so models give specific not generic advice.
-  Keep optimized_prompt concise — maximum 150 words. The research
-  panel will expand on it. Do not write a full brief here.
+optimized_prompt: A structured research brief for four AI research
+  models (Claude the ANALYST, GPT the PRAGMATIST, Gemini the SCOUT,
+  Grok the CHALLENGER). Write this brief to produce genuinely
+  different responses — not four versions of the same answer.
+
+  Using the context gathered in intake, construct a brief with
+  exactly these five elements (no section headers — write as prose):
+
+  1. THE DECISION — One sentence, "Should X do Y" form.
+     Lead with the decision, not the background.
+
+  2. THE TENSION — One or two sentences naming the two competing
+     considerations that make this hard. If there is no genuine
+     tension, the question is not worth a roundtable.
+
+  3. THE WRONG ANSWER — One sentence: "A wrong answer would be
+     one that ignores Z." This prevents lazy consensus.
+
+  4. THE OUTPUT FORMAT — One or two sentences specifying what the
+     user will DO with this output. Use the output_intent field.
+     Frame as a decision brief, risk brief, or action plan — each
+     is structured differently.
+
+  5. THE PRESSURE — One sentence: state the timeline and what
+     changes if the deadline is missed.
+
+  Stakes: infer from topic (immigration/medical/financial = high
+  stakes, general research = standard). Reflect stakes in how
+  you frame the tension and wrong-answer sections.
+
+  Populate using: problem (user's original prompt + intake answers),
+  output_intent, user_context, timeline_pressure from what you
+  gathered in intake.
+
+  Preserve ALL user-provided proper nouns exactly as written.
+  No preamble. No explanation. The brief must read as if handed
+  to a senior analyst, not typed into a chatbot.
 
 tier: always "smart". The user controls tier via the session UI.
 
@@ -325,14 +356,18 @@ output_intent: what the user wants to walk away with — the answer
 ## Quality Bar for the Optimized Prompt
 
 The optimized_prompt must:
+- Open with the decision in "Should X do Y" form — not background
+- Name the genuine tension (two competing considerations that make
+  this hard)
+- Identify what a wrong answer would look like
+- Specify the output format using output_intent (decision brief,
+  risk brief, or action plan are structured differently)
+- Close with one sentence of timeline pressure
 - Contain no assumptions that were not confirmed in intake
-- Specify the user's exact situation including immigration details
-- Name the desired output format explicitly
-- Include constraints that will affect the answer
-- Be specific enough that two different frontier models produce
-  meaningfully different, non-generic responses
 - For immigration cases: include visa type, case stage, and
-  employer dependency so models give specific not generic advice
+  employer dependency in the tension and wrong-answer sections
+- Preserve ALL user-provided proper nouns exactly
+- Read as if handed to a senior analyst, not typed into a chatbot
 
 CRITICAL OUTPUT FORMAT: Return raw JSON only. No markdown. \
 No backtick fences. No prose before or after the JSON object. \


### PR DESCRIPTION
## Summary

- The `optimized_prompt` was previously a concise restatement of the problem (≤150 words)
- All four research models received nearly identical briefs → convergent, redundant answers
- New format produces a structured research brief that forces genuine divergence

## The 5-section brief format

| Section | Purpose |
|---|---|
| **DECISION** | "Should X do Y" — leads with the decision, not background |
| **TENSION** | Two competing considerations that make this hard |
| **WRONG ANSWER** | What lazy consensus looks like — prevents the models from agreeing for the wrong reasons |
| **OUTPUT FORMAT** | Frames the brief using `output_intent` (decision brief / risk brief / action plan are structured differently) |
| **PRESSURE** | Timeline + what changes if the deadline is missed |

## Model roles made explicit

The brief explicitly names the four models and their roles:
- Claude (ANALYST) — first principles
- GPT (PRAGMATIST) — practical reality
- Gemini (SCOUT) — angles others miss
- Grok (CHALLENGER) — stress-tests the premise

## Implementation

Single change to `_build_intake_system_prompt()` in `backend/models/openai_client.py`. The intake model already has all the context (gathered during multi-turn conversation), so this adds zero latency. No additional API calls.

## Test plan

- [ ] Enter the H-1B immigration prompt and complete all intake questions
- [ ] Verify the OPTIMIZED PROMPT panel shows a structured brief with the 5 elements
- [ ] Confirm the brief opens with "Should X do Y" form
- [ ] Start research — verify Claude, GPT, Gemini, Grok give meaningfully different responses
- [ ] 246 tests passing: `uv run pytest tests/ -x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)