### PR TITLE
fix(grok): load .env before reading GROK_API_KEY

### DIFF
--- a/backend/models/grok_client.py
+++ b/backend/models/grok_client.py
@@ -25,6 +25,10 @@ Functions:
 import asyncio
 import os
 from functools import partial
+from pathlib import Path
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 
 from openai import OpenAI
 

--- a/backend/models/model_validator.py
+++ b/backend/models/model_validator.py
@@ -14,7 +14,11 @@ check_model_currency():
 
 import logging
 import os
+from pathlib import Path
 from typing import Optional
+
+from dotenv import load_dotenv
+load_dotenv(Path(__file__).parent.parent / ".env", override=True)
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +75,7 @@ def _list_xai_models() -> set:
         response = httpx.get(
             "https://api.x.ai/v1/models",
             headers={
-                "Authorization": f"Bearer {os.environ.get('XAI_API_KEY', '')}"
+                "Authorization": f"Bearer {os.environ.get('GROK_API_KEY', '')}"
             },
             timeout=10,
         )


### PR DESCRIPTION
## Problem
Grok API key was not loading from backend/.env despite being set.
Bearer warning on every startup.

## Root cause — two files
- grok_client.py — missing load_dotenv call
- model_validator.py — missing load_dotenv AND reading XAI_API_KEY 
  instead of GROK_API_KEY

## Fix
- Added load_dotenv(Path(__file__).parent.parent / ".env", override=True) 
  to both files
- Fixed env var name in model_validator.py: XAI_API_KEY → GROK_API_KEY

## Result
- Bearer warning gone from startup logs
- Grok API key loads correctly from .env

## Tests
250 passing