### PR TITLE
fix: enforce track parity in multi-track synthesis

### DIFF
--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -369,6 +369,20 @@ The optimized_prompt must:
 - Preserve ALL user-provided proper nouns exactly
 - Read as if handed to a senior analyst, not typed into a chatbot
 
+MULTI-TRACK RULE: If the user's output intent specifies two or more parallel \
+tracks (e.g. "a career plan AND an immigration sequence", "a technical roadmap \
+AND a risk analysis"), the optimized_prompt MUST close with this exact \
+instruction after the pressure sentence: \
+\
+"TRACK PARITY REQUIRED: This brief has [N] parallel tracks. The panel must \
+address all [N] tracks with equal depth. Track [1]: [name]. Track [2]: [name]. \
+The synthesis must produce a verdict that covers every track. A response that \
+covers one track thoroughly while neglecting another is an incomplete answer \
+regardless of depth." \
+\
+Replace [N] and [name] with the actual count and track names from the user's \
+intake. If only one track exists, do not add this instruction. \
+
 CRITICAL OUTPUT FORMAT: Return raw JSON only. No markdown. \
 No backtick fences. No prose before or after the JSON object. \
 Your response must start with '{' and end with '}'. \

--- a/backend/router.py
+++ b/backend/router.py
@@ -113,6 +113,12 @@ GAPS
 Important angles the prompt required but none of the models addressed.
 Format: "None of the models addressed [X], which matters because [Y]."
 
+TRACK COLLAPSE
+If the research brief specified multiple parallel tracks, check whether all
+four model responses addressed every track. If any model focused exclusively
+on one track and ignored another, flag it here:
+TRACK_COLLAPSE: [list which models collapsed which tracks, or "none detected"]
+
 PERPLEXITY CONFLICTS
 Contradictions between Perplexity's live findings and round-1 model claims.
 Format: "Perplexity says [X]. [Model] claimed [Y]. [RESOLVED: Perplexity wins]"
@@ -698,6 +704,16 @@ Do not show this reasoning in your output:
 ## Output Format
 
 Write your response in exactly four labeled sections using bold headers:
+
+TRACK COVERAGE CHECK: Before writing THE VERDICT, check whether the research
+brief specified multiple parallel tracks. If yes:
+- THE VERDICT must address each track in separate paragraphs, one per track.
+- THE HINGE must identify the constraint that governs the most important track
+  — not necessarily the most emotionally urgent one.
+- ONE NEXT ACTION must serve the track the user asked about first, not the
+  track with the highest-stakes language.
+A verdict that covers one track and neglects another is an incomplete
+synthesis. Rewrite it until all tracks are represented.
 
 **THE VERDICT**
 One to three sentences. State what the user should do and the single most


### PR DESCRIPTION
Root cause: when a brief contained two parallel tracks (e.g. career strategy + immigration sequencing), the synthesis collapsed into the track with the highest-stakes emotional language, leaving the other absent from THE VERDICT, THE HINGE, and ONE NEXT ACTION.

Three prompt layers updated:

Layer 1 (openai_client.py — _build_intake_system_prompt):
- Add MULTI-TRACK RULE: when output intent names ≥2 parallel tracks, the optimized brief must close with a TRACK PARITY REQUIRED instruction naming each track and its index

Layer 2 (router.py — SYNTHESIS_SYSTEM_PROMPT):
- Add TRACK COVERAGE CHECK before THE VERDICT: verdict must address each track in separate paragraphs; THE HINGE must target the most important track (not the most emotionally urgent); ONE NEXT ACTION must serve the track the user named first

Layer 3 (router.py — SELF_CRITIQUE_SYSTEM):
- Add TRACK COLLAPSE check after GAPS: flags any model that focused exclusively on one track and ignored another before synthesis