### PR TITLE
feat(intake): add background context question as universal pre-flight

### DIFF
--- a/backend/intake.py
+++ b/backend/intake.py
@@ -81,6 +81,23 @@ _OUTPUT_INTENT_FALLBACK: dict = {
     ],
 }
 
+BACKGROUND_CONTEXT_QUESTION: dict = {
+    "question": (
+        "Tell me a bit about yourself — your current role, "
+        "relevant background, and what you're working on. "
+        "This helps the panel give you advice that fits your actual situation."
+    ),
+    "options": [
+        "Software / Data Engineer transitioning to AI",
+        "Product Manager exploring AI tools",
+        "Founder / Independent builder",
+        "Student or early career",
+        "Other — I'll type it",
+    ],
+}
+
+BACKGROUND_CONTEXT_DEFAULT = "Not provided — treat as general professional context"
+
 FALLBACK_QUESTIONS: dict[str, list[dict]] = {
     "immigration_legal": [
         {
@@ -362,6 +379,8 @@ class IntakeSession:
         self.detected_domain: Optional[str] = None
         self._asked_questions: list[str] = []
         self._qa_history: list[tuple[str, str]] = []
+        self._background_context: Optional[str] = None
+        self._background_answered: bool = False
 
     def start(self) -> str:
         """
@@ -391,6 +410,18 @@ class IntakeSession:
         self._original_prompt = prompt
         self.detected_domain = _detect_domain(prompt)
 
+        # Background context question fires first on every session before any
+        # model call. Not counted toward MINIMUM_QUESTIONS_REQUIRED enforcement.
+        if not self._background_answered:
+            q = BACKGROUND_CONTEXT_QUESTION
+            self._clarifying_question = q["question"]
+            return {
+                "status": "clarifying",
+                "clarifying_question": q["question"],
+                "suggested_options": q["options"],
+                "config": None,
+            }
+
         decision, provider_used = call_intake(prompt)
         self._intake_provider = provider_used
         return self._route_decision(decision, context_text=prompt)
@@ -410,12 +441,36 @@ class IntakeSession:
                 "config": self.session_config,
             }
 
+        # Intercept the answer to the pre-flight background context question.
+        # Store it, mark background as answered, then run the real intake model.
+        if not self._background_answered:
+            bg = answer.strip()
+            self._background_context = bg if bg else BACKGROUND_CONTEXT_DEFAULT
+            self._background_answered = True
+            self._clarifying_question = None
+            # Detect domain from the original prompt only — before adding the
+            # background answer to history. Background answers often mention
+            # career words ("transitioning") that would falsely trigger domain
+            # detection if included in the accumulated context at this stage.
+            if self.detected_domain is None:
+                self.detected_domain = _detect_domain(self._original_prompt or "")
+            self._qa_history.append((
+                BACKGROUND_CONTEXT_QUESTION["question"],
+                self._background_context,
+            ))
+            combined = self._build_combined_prompt()
+            decision, provider_used = call_intake(combined)
+            self._intake_provider = provider_used
+            return self._route_decision(decision, context_text=self._accumulated_context())
+
         if self._clarifying_question:
             self._qa_history.append((self._clarifying_question, answer))
 
         # Domain may become detectable only after the user elaborates.
+        # Exclude background Q&A from domain detection — background answers
+        # describe who the user is, not what decision domain they are in.
         if self.detected_domain is None:
-            self.detected_domain = _detect_domain(self._accumulated_context())
+            self.detected_domain = _detect_domain(self._accumulated_context_for_domain())
 
         combined = self._build_combined_prompt()
         decision, provider_used = call_intake(combined)
@@ -509,6 +564,9 @@ class IntakeSession:
         # Close the session.
         self.complete = True
         self.session_config = _decision_to_config(decision)
+        self.session_config["background_context"] = (
+            self._background_context or BACKGROUND_CONTEXT_DEFAULT
+        )
         return {
             "status": "complete",
             "clarifying_question": None,
@@ -544,6 +602,21 @@ class IntakeSession:
         """Concatenate original prompt + all Q/A pairs for domain detection + guard checks."""
         parts: list[str] = [self._original_prompt or ""]
         for q, a in self._qa_history:
+            parts.append(f"Q: {q}\nA: {a}")
+        return "\n".join(parts)
+
+    def _accumulated_context_for_domain(self) -> str:
+        """Like _accumulated_context but strips the background Q&A entry.
+
+        Background answers describe the user's role/career and often contain
+        words like 'transitioning' that would falsely trigger domain detection.
+        Domain should be inferred from what the user is deciding, not who they are.
+        """
+        parts: list[str] = [self._original_prompt or ""]
+        bg_q = BACKGROUND_CONTEXT_QUESTION["question"]
+        for q, a in self._qa_history:
+            if q == bg_q:
+                continue
             parts.append(f"Q: {q}\nA: {a}")
         return "\n".join(parts)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -306,6 +306,9 @@ def _enrich_prompt(base_prompt: str, config: dict) -> str:
       should treat these as open variables, not assume defaults.
     """
     prompt = base_prompt
+    background_context = config.get("background_context") or ""
+    if background_context:
+        prompt += f"\n\nUser background: {background_context}"
     corrected = config.get("corrected_assumptions") or []
     open_qs = config.get("open_questions") or []
     if corrected:
@@ -372,7 +375,9 @@ async def session_run(req: SessionRunRequest):
                 content=msg["content"],
                 round=msg.get("round", "round1"),
             )
-    transcript.add_user_message(req.prompt)
+    # Use the enriched prompt (includes background_context) as the research message
+    # so all four panel models have the user's background as part of their context.
+    transcript.add_user_message(optimized_prompt)
 
     gemini_history = transcript.get_history_for_model("gemini")
     gpt_history    = transcript.get_history_for_model("gpt")
@@ -1021,7 +1026,8 @@ async def session_websocket(websocket: WebSocket):
         tier = "smart"
     health = PipelineHealth()
     optimized_prompt = _enrich_prompt(config.get("optimized_prompt", prompt), config)
-    transcript = _build_transcript(config, history, prompt)
+    # Use enriched prompt so all four panel models have background_context in context.
+    transcript = _build_transcript(config, history, optimized_prompt)
 
     dialogue_queue: asyncio.Queue = asyncio.Queue()
     ping_task = asyncio.create_task(_drain_client_messages(websocket, dialogue_queue))

--- a/backend/models/openai_client.py
+++ b/backend/models/openai_client.py
@@ -331,6 +331,11 @@ optimized_prompt: A structured research brief for four AI research
   stakes, general research = standard). Reflect stakes in how
   you frame the tension and wrong-answer sections.
 
+  If the Q&A history contains an answer to "Tell me a bit about
+  yourself", include a "User background: [their answer]" line
+  in the brief, positioned immediately after the decision
+  statement and before THE TENSION.
+
   Populate using: problem (user's original prompt + intake answers),
   output_intent, user_context, timeline_pressure from what you
   gathered in intake.

--- a/tests/test_gemini_intake.py
+++ b/tests/test_gemini_intake.py
@@ -61,7 +61,10 @@ FINAL_DECISION = _decision(
 def test_clear_prompt_completes_in_one_turn():
     with patch("backend.intake.call_intake_sonnet", return_value=CLEAR_DECISION):
         session = IntakeSession()
-        result = session.analyze("How do I design a RAG pipeline?")
+        r0 = session.analyze("How do I design a RAG pipeline?")
+        # Background context question fires first on every session.
+        assert r0["status"] == "clarifying"
+        result = session.respond("Software / Data Engineer transitioning to AI")
 
     assert result["status"] == "complete"
     assert result["config"] is not None
@@ -94,8 +97,11 @@ def test_ambiguous_prompt_returns_clarifying_question():
 def test_clarification_answer_completes_session():
     with patch("backend.intake.call_intake_sonnet", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]):
         session = IntakeSession()
-        r1 = session.analyze("I need help with my project")
-        assert r1["status"] == "clarifying"
+        r0 = session.analyze("I need help with my project")
+        assert r0["status"] == "clarifying"  # background context question
+
+        r1 = session.respond("Software / Data Engineer transitioning to AI")
+        assert r1["status"] == "clarifying"  # domain question from AMBIGUOUS_DECISION
 
         r2 = session.respond("A written report for my team")
 
@@ -114,7 +120,8 @@ def test_tier_is_always_smart():
     decision = _decision(tier="smart")
     with patch("backend.intake.call_intake_sonnet", return_value=decision):
         session = IntakeSession()
-        result = session.analyze("Test prompt")
+        session.analyze("Test prompt")
+        result = session.respond("Software / Data Engineer transitioning to AI")
     assert result["config"]["tier"] == "smart"
 
 
@@ -163,7 +170,8 @@ def test_architecture_prompt_maps_to_smart_tier():
     )
     with patch("backend.intake.call_intake_sonnet", return_value=arch_decision):
         session = IntakeSession()
-        result = session.analyze("Design the architecture for a real-time data processing pipeline")
+        session.analyze("Design the architecture for a real-time data processing pipeline")
+        result = session.respond("Software / Data Engineer transitioning to AI")
 
     assert result["config"]["tier"] == "smart"
 
@@ -178,7 +186,8 @@ def test_comparison_prompt_maps_to_smart_tier():
     )
     with patch("backend.intake.call_intake_sonnet", return_value=comparison_decision):
         session = IntakeSession()
-        result = session.analyze("Compare PostgreSQL vs MongoDB for a read-heavy web application")
+        session.analyze("Compare PostgreSQL vs MongoDB for a read-heavy web application")
+        result = session.respond("Software / Data Engineer transitioning to AI")
 
     assert result["config"]["tier"] == "smart"
 
@@ -190,11 +199,14 @@ def test_comparison_prompt_maps_to_smart_tier():
 def test_second_respond_returns_existing_config_without_api_call():
     with patch("backend.intake.call_intake_sonnet", side_effect=[AMBIGUOUS_DECISION, FINAL_DECISION]) as mock_api:
         session = IntakeSession()
-        session.analyze("Ambiguous prompt")
-        session.respond("First answer")
+        session.analyze("Ambiguous prompt")  # background question — no API call
+        session.respond("Software / Data Engineer transitioning to AI")  # bg answer → call #1 (AMBIGUOUS_DECISION)
+        assert mock_api.call_count == 1
+
+        session.respond("First domain answer")  # domain answer → call #2 (FINAL_DECISION)
         assert mock_api.call_count == 2
 
-        # Second respond() — session is already complete, should not call API again
+        # Session is now complete — third respond() must not call API again
         result = session.respond("Another answer")
         assert mock_api.call_count == 2  # no third call
 
@@ -371,7 +383,9 @@ def test_clarifying_question_with_substituted_names_is_detectable():
     """
     with patch("backend.intake.call_intake_sonnet", return_value=_SUBSTITUTED_QUESTION):
         session = IntakeSession()
-        result = session.analyze(_PRICING_PROMPT)
+        session.analyze(_PRICING_PROMPT)
+        # Answer background context question first; domain question comes next.
+        result = session.respond("Software / Data Engineer transitioning to AI")
 
     q = result["clarifying_question"]
     # These assertions should FAIL against the bad response — confirming detection works.
@@ -417,6 +431,9 @@ def test_turn1_optimized_prompt_preserves_original_model_names():
                side_effect=[_INTENT_ONLY_QUESTION, _PRESERVED_FINAL]):
         session = IntakeSession()
         session.analyze(_PRICING_PROMPT)
+        # Answer background context question; _INTENT_ONLY_QUESTION fires as domain question.
+        session.respond("Software / Data Engineer transitioning to AI")
+        # Answer domain question; _PRESERVED_FINAL closes with the preserved prompt.
         result = session.respond("Standard API pricing")
 
     op = result["config"]["optimized_prompt"]
@@ -438,6 +455,9 @@ def test_turn1_substituted_prompt_is_detectable():
                side_effect=[_INTENT_ONLY_QUESTION, _SUBSTITUTED_FINAL]):
         session = IntakeSession()
         session.analyze(_PRICING_PROMPT)
+        # Answer background context question; _INTENT_ONLY_QUESTION fires as domain question.
+        session.respond("Software / Data Engineer transitioning to AI")
+        # Answer domain question; _SUBSTITUTED_FINAL closes with the bad prompt.
         result = session.respond("Standard API pricing")
 
     op = result["config"]["optimized_prompt"]

--- a/tests/test_intake_quality.py
+++ b/tests/test_intake_quality.py
@@ -72,7 +72,8 @@ class TestImmigrationGuard:
     def test_intake_guard_fires_on_unknown_visa_type(self):
         """
         If the model returns needs_clarification=False but visa_type is 'unknown',
-        IntakeSession.analyze() must return status='clarifying' with a probing question.
+        the guard must return status='clarifying' with a visa probing question.
+        Background context question fires first; guard fires on the first respond().
         """
         from backend.intake import IntakeSession
 
@@ -85,7 +86,9 @@ class TestImmigrationGuard:
 
         with patch("backend.intake.call_intake", return_value=(decision_with_unknown_visa, "claude")):
             session = IntakeSession()
-            result = session.analyze("I have an active immigration case and am considering leaving my job")
+            bg = session.analyze("I have an active immigration case and am considering leaving my job")
+            assert bg["status"] == "clarifying"  # background context question
+            result = session.respond("Software / Data Engineer transitioning to AI")
 
         assert result["status"] == "clarifying", (
             "Guard should force clarifying status when visa_type is unknown"
@@ -351,8 +354,9 @@ class TestSuggestedOptions:
 
     def test_analyze_includes_suggested_options_in_clarifying_response(self):
         """
-        IntakeSession.analyze() includes 'suggested_options' in the clarifying
-        response dict when the model asks a clarifying question.
+        IntakeSession includes 'suggested_options' in the clarifying response dict
+        when the model asks a clarifying question. Background context question fires
+        first; domain question (with options) comes after the first respond().
         """
         from backend.intake import IntakeSession
         from backend.models.intake_decision import IntakeDecision
@@ -371,7 +375,9 @@ class TestSuggestedOptions:
             "backend.intake.call_intake", return_value=(decision_with_question, "claude")
         ):
             session = IntakeSession()
-            result = session.analyze("I have a visa and want to change jobs")
+            bg = session.analyze("I have a visa and want to change jobs")
+            assert bg["status"] == "clarifying"  # background context question
+            result = session.respond("Software / Data Engineer transitioning to AI")
 
         assert result["status"] == "clarifying"
         assert "suggested_options" in result
@@ -380,7 +386,8 @@ class TestSuggestedOptions:
     def test_immigration_guard_provides_visa_type_options(self):
         """
         When the immigration guard fires (visa_type unknown), the clarifying
-        response includes the standard visa type options.
+        response includes the standard visa type options. Background context
+        question fires first; guard fires on the first respond().
         """
         from backend.intake import IntakeSession
 
@@ -393,7 +400,8 @@ class TestSuggestedOptions:
             "backend.intake.call_intake", return_value=(decision_no_visa, "claude")
         ):
             session = IntakeSession()
-            result = session.analyze("I have an active immigration case and want to leave my job")
+            session.analyze("I have an active immigration case and want to leave my job")
+            result = session.respond("Software / Data Engineer transitioning to AI")
 
         assert result["status"] == "clarifying"
         assert "suggested_options" in result
@@ -412,13 +420,16 @@ class TestMinimumQuestionsEnforcement:
 
     def test_minimum_questions_enforced_immigration(self):
         """
-        Immigration domain requires 3 clarifying turns. If the model returns
-        needs_clarification=False after only 1 answer, intake must NOT close —
-        a fallback question is forced instead.
+        Immigration domain requires 4 clarifying turns. If the model returns
+        needs_clarification=False after only 1 domain answer, intake must NOT
+        close — a fallback question is forced instead.
+
+        Background context question fires first and is not counted toward the
+        per-domain minimum. Turn 0 (first domain question) fires on respond(bg).
         """
         from backend.intake import IntakeSession, MINIMUM_QUESTIONS_REQUIRED
 
-        # Turn 0: model asks a clarifying question (legitimate)
+        # Turn 0: model asks a clarifying question (legitimate, fired after bg answer)
         turn0 = IntakeDecision(
             needs_clarification=True,
             clarifying_question="What visa type are you currently on?",
@@ -437,19 +448,25 @@ class TestMinimumQuestionsEnforcement:
         with patch("backend.intake.call_intake",
                    side_effect=[(turn0, "claude"), (turn1_closed, "claude")]):
             session = IntakeSession()
-            r0 = session.analyze(
-                "I'm on H-1B with pending green card and considering a new job"
-            )
-            assert r0["status"] == "clarifying"
+
+            # Background question fires first — no intake call yet.
+            bg = session.analyze("I'm on H-1B with pending green card and considering a new job")
+            assert bg["status"] == "clarifying"
             assert session.detected_domain == "immigration_legal"
+            assert session.questions_asked == 0  # background not counted
+
+            # Answer background → intake fires turn0 (domain question, questions_asked=1).
+            r0 = session.respond("Software / Data Engineer transitioning to AI")
+            assert r0["status"] == "clarifying"
             assert session.questions_asked == 1
 
+            # Answer domain question → intake fires turn1_closed.
             r1 = session.respond("H-1B with I-140 approved")
 
-        # Model tried to close after 1 answer. Minimum for immigration_legal is 3.
-        # After the forced fallback, questions_asked=2 — still below min=3.
+        # Model tried to close after 1 domain answer. Minimum for immigration_legal is 4.
+        # A fallback question is forced; questions_asked=2 — still below min=4.
         assert r1["status"] == "clarifying", (
-            "Intake must NOT close before immigration_legal minimum (3) is reached"
+            "Intake must NOT close before immigration_legal minimum (4) is reached"
         )
         assert session.complete is False
         assert r1["config"] is None
@@ -461,9 +478,12 @@ class TestMinimumQuestionsEnforcement:
 
     def test_minimum_questions_enforced_career(self):
         """
-        Career-transition domain requires 2 clarifying turns. If the model
-        returns needs_clarification=False after only 1 answer, intake must NOT
-        close — a fallback question is forced instead.
+        Career-transition domain requires 3 clarifying turns. If the model
+        returns needs_clarification=False after only 1 domain answer, intake
+        must NOT close — a fallback question is forced instead.
+
+        Background context question fires first and is not counted toward the
+        per-domain minimum. Turn 0 (first domain question) fires on respond(bg).
         """
         from backend.intake import IntakeSession, MINIMUM_QUESTIONS_REQUIRED
 
@@ -484,20 +504,25 @@ class TestMinimumQuestionsEnforcement:
         with patch("backend.intake.call_intake",
                    side_effect=[(turn0, "claude"), (turn1_closed, "claude")]):
             session = IntakeSession()
-            r0 = session.analyze(
-                "I have a job offer at a new company and need to decide whether to leave"
-            )
-            assert r0["status"] == "clarifying"
+
+            # Background question fires first — no intake call yet.
+            bg = session.analyze("I have a job offer at a new company and need to decide whether to leave")
+            assert bg["status"] == "clarifying"
             assert session.detected_domain == "career_transition"
+            assert session.questions_asked == 0  # background not counted
+
+            # Answer background → intake fires turn0 (domain question, questions_asked=1).
+            r0 = session.respond("Software / Data Engineer transitioning to AI")
+            assert r0["status"] == "clarifying"
             assert session.questions_asked == 1
 
+            # Answer domain question → intake fires turn1_closed.
             r1 = session.respond("Senior backend engineer at a series B")
 
-        # Model tried to close after 1 answer. Minimum for career_transition is 2.
-        # The forced fallback pushes questions_asked to the minimum — the
-        # session is still open because a second answer has not yet arrived.
+        # Model tried to close after 1 domain answer. Minimum for career_transition is 3.
+        # The forced fallback is still open — session needs more turns.
         assert r1["status"] == "clarifying", (
-            "Intake must NOT close before career_transition minimum (2) is reached"
+            "Intake must NOT close before career_transition minimum (3) is reached"
         )
         assert session.complete is False
         assert r1["clarifying_question"] is not None
@@ -509,6 +534,11 @@ class TestMinimumQuestionsEnforcement:
         """
         Once the domain minimum has been met and the model returns
         needs_clarification=False, intake closes normally.
+
+        Background context question fires first (no intake call). The five
+        intake side_effects are consumed by five respond() calls, with the
+        first respond() answering the background question and triggering the
+        first domain question.
         """
         from backend.intake import IntakeSession, MINIMUM_QUESTIONS_REQUIRED
 
@@ -532,15 +562,16 @@ class TestMinimumQuestionsEnforcement:
         with patch(
             "backend.intake.call_intake",
             side_effect=[
-                (q("What visa type are you on?"), "claude"),
-                (q("What stage is your case at?"), "claude"),
-                (q("Has the new employer confirmed sponsorship?"), "claude"),
-                (q("What do you want to walk away with?"), "claude"),
-                (final, "claude"),
+                (q("What visa type are you on?"), "claude"),          # respond(bg)
+                (q("What stage is your case at?"), "claude"),         # respond("H-1B")
+                (q("Has the new employer confirmed sponsorship?"), "claude"),  # respond("I-140 approved")
+                (q("What do you want to walk away with?"), "claude"), # respond("Yes, confirmed")
+                (final, "claude"),                                    # respond("A clear recommendation")
             ],
         ):
             session = IntakeSession()
             session.analyze("I'm on H-1B with a green card pending and considering a new job")
+            session.respond("Software / Data Engineer transitioning to AI")  # bg answer
             session.respond("H-1B")
             session.respond("I-140 approved")
             session.respond("Yes, confirmed sponsorship")


### PR DESCRIPTION
## What
Adds a background context question that fires first on every session
before domain-specific questions begin. The user's answer is injected
into the optimized brief, the research panel transcript, and the
Perplexity/synthesis context — so all four models know who they are
talking to.

## Why
Competitive analysis (April 27 2026) against Claude.ai, Gemini, GPT,
Grok, Perplexity, and Ithy showed all six single-model tools produced
better career track output than ai-roundtable. Root cause: every user
was treated as anonymous. Claude.ai produced personalized output
because it had conversation history. ai-roundtable had none.

One background question closes this gap systematically.

## What changed — 5 files
- backend/intake.py — BACKGROUND_CONTEXT_QUESTION constant,
  background preflight logic, domain detection fix to exclude
  background Q&A from minimum question count
- backend/models/openai_client.py — intake system prompt updated
  to include "User background:" line in optimized brief
- backend/main.py — _enrich_prompt() injects background_context;
  research transcript switched to enriched optimized_prompt
- tests/test_gemini_intake.py — 15 tests updated for background
  preflight
- tests/test_intake_quality.py — same

## Domain detection fix
Background answer "transitioning to AI" was triggering career
domain detector and inflating minimum question counts.
Fixed with _accumulated_context_for_domain() helper that strips
background Q&A before domain classification.

## Tests
250 passing